### PR TITLE
Replace uses of "PyCon" with "EuroPython" as far as possible (part 2)

### DIFF
--- a/data/static/ep2015/stylesheets/_imports.scss
+++ b/data/static/ep2015/stylesheets/_imports.scss
@@ -83,7 +83,7 @@ URL: http://stuffandnonsense.co.uk/projects/rock-hammer/
 @import "partials/navigation-responsive-nav";
 //@import "partials/navigation-responsive-breadcrumb";
 
-// Styles for specific PyCon sections
+// Styles for specific EuroPython sections
 
 @import "partials/pycon/legacy";
 @import "partials/pycon/blog";

--- a/data/static/ep2015/stylesheets/all.css
+++ b/data/static/ep2015/stylesheets/all.css
@@ -63,13 +63,13 @@ body { margin: 0; padding: 0; width: 100%; background-color: transparent; font-f
 .media-body { text-align: center; }
 .media-body h3 { padding-top: 5px; }
 
-.learn-with-pycon { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
-/*.learn-with-pycon { background-image: url("../images/bg-us.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }*/
+.learn-with-europython { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
+/*.learn-with-europython { background-image: url("../images/bg-us.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }*/
 
-.learn-with-pycon a:hover { text-decoration: none; }
-.learn-with-pycon p { text-align: center; color: #333333; } /*CHANGED: to DARK GRAY*/
-.learn-with-pycon h2 { margin: 0 0 0.5em 0; }
-.learn-with-pycon h4 { color: #333333; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
+.learn-with-europython a:hover { text-decoration: none; }
+.learn-with-europython p { text-align: center; color: #333333; } /*CHANGED: to DARK GRAY*/
+.learn-with-europython h2 { margin: 0 0 0.5em 0; }
+.learn-with-europython h4 { color: #333333; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
 
 .learn-icon, .subcommunities .subcommunity-container { background-color: white; border-radius: 50%; width: 100px; height: 100px; border: 5px solid #f5ad58; margin: 0 auto; margin-bottom: 20px; margin-top: 15px; padding: 21px; }
 
@@ -108,7 +108,7 @@ footer table { margin: 0 auto; }
 
 /*#navigation-toggle { border-bottom: 5px solid #646464; }*/
 
-/*header { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; }*/
+/*header { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; }*/
 header { background-image: url("../images/bg-gug-new.png"); background-size: cover; background-repeat: no-repeat; background-attachment: fixed; background-position: center; }
 
 /*QUOTE THEME COLOR*/

--- a/data/static/ep2015/stylesheets/lte-ie8.css
+++ b/data/static/ep2015/stylesheets/lte-ie8.css
@@ -52,11 +52,11 @@ body { margin: 0; padding: 0; width: 100%; background-color: transparent; font-f
 .media-body { text-align: center; }
 .media-body h3 { padding-top: 5px; }
 
-.learn-with-pycon { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
-.learn-with-pycon a:hover { text-decoration: none; }
-.learn-with-pycon p { text-align: center; color: #555555; }
-.learn-with-pycon h2 { margin: 0 0 0.5em 0; }
-.learn-with-pycon h4 { color: #555555; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
+.learn-with-europython { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
+.learn-with-europython a:hover { text-decoration: none; }
+.learn-with-europython p { text-align: center; color: #555555; }
+.learn-with-europython h2 { margin: 0 0 0.5em 0; }
+.learn-with-europython h4 { color: #555555; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
 
 .learn-icon, .subcommunities .subcommunity-container { background-color: white; border-radius: 50%; width: 100px; height: 100px; border: 5px solid #e61f4b; margin: 0 auto; margin-bottom: 20px; margin-top: 15px; padding: 21px; }
 
@@ -76,7 +76,7 @@ footer table { margin: 0 auto; }
 
 #navigation-toggle { border-bottom: 5px solid #e61f4b; }
 
-header { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; }
+header { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; }
 
 .quote-section { background: #555; color: white; }
 .quote-section q { font-size: 30px; font-size: 3rem; line-height: 1.2; font-weight: 500; text-transform: uppercase; margin-bottom: 30px; display: block; }

--- a/data/static/ep2015/stylesheets/partials/_site.scss
+++ b/data/static/ep2015/stylesheets/partials/_site.scss
@@ -160,8 +160,8 @@ body {
     }
 }
 
-.learn-with-pycon {
-    background-image: url("../images/bg-learn-with-pycon.jpg");
+.learn-with-europython {
+    background-image: url("../images/bg-learn-with-europython.jpg");
     background-size: cover;
     background-position: center top;
     background-repeat: no-repeat;
@@ -257,7 +257,7 @@ footer {
 }
 
 header {
-    background-image: url("../images/bg-learn-with-pycon.jpg");
+    background-image: url("../images/bg-learn-with-europython.jpg");
     background-size: cover;
 }
 

--- a/data/static/p5/stylesheets/_imports.scss
+++ b/data/static/p5/stylesheets/_imports.scss
@@ -83,7 +83,7 @@ URL: http://stuffandnonsense.co.uk/projects/rock-hammer/
 @import "partials/navigation-responsive-nav";
 //@import "partials/navigation-responsive-breadcrumb";
 
-// Styles for specific PyCon sections
+// Styles for specific EuroPython sections
 
 @import "partials/pycon/legacy";
 @import "partials/pycon/blog";

--- a/data/static/p6/stylesheets/_imports.scss
+++ b/data/static/p6/stylesheets/_imports.scss
@@ -83,7 +83,7 @@ URL: http://stuffandnonsense.co.uk/projects/rock-hammer/
 @import "partials/navigation-responsive-nav";
 //@import "partials/navigation-responsive-breadcrumb";
 
-// Styles for specific PyCon sections
+// Styles for specific EuroPython sections
 
 @import "partials/pycon/legacy";
 @import "partials/pycon/blog";

--- a/data/static/p6/stylesheets/all.css
+++ b/data/static/p6/stylesheets/all.css
@@ -52,11 +52,11 @@ body { margin: 0; padding: 0; width: 100%; background-color: transparent; font-f
 .media-body { text-align: center; }
 .media-body h3 { padding-top: 5px; }
 
-.learn-with-pycon { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
-.learn-with-pycon a:hover { text-decoration: none; }
-.learn-with-pycon p { text-align: center; color: #555555; }
-.learn-with-pycon h2 { margin: 0 0 0.5em 0; }
-.learn-with-pycon h4 { color: #555555; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
+.learn-with-europython { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
+.learn-with-europython a:hover { text-decoration: none; }
+.learn-with-europython p { text-align: center; color: #555555; }
+.learn-with-europython h2 { margin: 0 0 0.5em 0; }
+.learn-with-europython h4 { color: #555555; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
 
 .learn-icon, .subcommunities .subcommunity-container { background-color: white; border-radius: 50%; width: 100px; height: 100px; border: 5px solid #E5781E; margin: 0 auto; margin-bottom: 20px; margin-top: 15px; padding: 21px; }
 
@@ -76,7 +76,7 @@ footer table { margin: 0 auto; }
 
 #navigation-toggle { border-bottom: 5px solid #E5781E; }
 
-header { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; }
+header { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; }
 
 .quote-section { background: #555; color: white; }
 .quote-section q { font-size: 30px; font-size: 3rem; line-height: 1.2; font-weight: 500; text-transform: uppercase; margin-bottom: 30px; display: block; }

--- a/data/static/p6/stylesheets/lte-ie8.css
+++ b/data/static/p6/stylesheets/lte-ie8.css
@@ -52,11 +52,11 @@ body { margin: 0; padding: 0; width: 100%; background-color: transparent; font-f
 .media-body { text-align: center; }
 .media-body h3 { padding-top: 5px; }
 
-.learn-with-pycon { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
-.learn-with-pycon a:hover { text-decoration: none; }
-.learn-with-pycon p { text-align: center; color: #555555; }
-.learn-with-pycon h2 { margin: 0 0 0.5em 0; }
-.learn-with-pycon h4 { color: #555555; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
+.learn-with-europython { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
+.learn-with-europython a:hover { text-decoration: none; }
+.learn-with-europython p { text-align: center; color: #555555; }
+.learn-with-europython h2 { margin: 0 0 0.5em 0; }
+.learn-with-europython h4 { color: #555555; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
 
 .learn-icon, .subcommunities .subcommunity-container { background-color: white; border-radius: 50%; width: 100px; height: 100px; border: 5px solid #e61f4b; margin: 0 auto; margin-bottom: 20px; margin-top: 15px; padding: 21px; }
 
@@ -76,7 +76,7 @@ footer table { margin: 0 auto; }
 
 #navigation-toggle { border-bottom: 5px solid #e61f4b; }
 
-header { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; }
+header { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; }
 
 .quote-section { background: #555; color: white; }
 .quote-section q { font-size: 30px; font-size: 3rem; line-height: 1.2; font-weight: 500; text-transform: uppercase; margin-bottom: 30px; display: block; }

--- a/data/static/p6/stylesheets/partials/_site.scss
+++ b/data/static/p6/stylesheets/partials/_site.scss
@@ -160,8 +160,8 @@ body {
     }
 }
 
-.learn-with-pycon {
-    background-image: url("../images/bg-learn-with-pycon.jpg");
+.learn-with-europython {
+    background-image: url("../images/bg-learn-with-europython.jpg");
     background-size: cover;
     background-position: center top;
     background-repeat: no-repeat;
@@ -257,7 +257,7 @@ footer {
 }
 
 header {
-    background-image: url("../images/bg-learn-with-pycon.jpg");
+    background-image: url("../images/bg-learn-with-europython.jpg");
     background-size: cover;
 }
 

--- a/documents/europython-mockups/blog-post.html
+++ b/documents/europython-mockups/blog-post.html
@@ -102,7 +102,7 @@
     <div class="blog-post">
         
 <rdf:rdf xmlns:trackback="http://madskills.com/public/xml/rss/module/trackback/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-<rdf:description trackback:ping="http://www.pycon.it/blog/2010/12/12/roma-call-for-paper-codemotion-2011/trackback" dc:title="Become a Codemotion Speaker" dc:identifier="http://www.pycon.it/blog/2010/12/12/rome-call-for-paper-codemotion-2011" rdf:about="http://www.pycon.it/blog/2010/12/12/rome-call-for-paper-codemotion-2011">
+<rdf:description trackback:ping="http://www.euroython.eu/blog/2010/12/12/roma-call-for-paper-codemotion-2011/trackback" dc:title="Become a Codemotion Speaker" dc:identifier="http://www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011" rdf:about="http://www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">
 </rdf:description>
 
 
@@ -143,11 +143,11 @@ For information: <a href="http://www.codemotion.it/en">www.codemotion.it</a></p>
         <ul>
             <li>
                 <!-- delicious  -->
-                <img width="16" height="16" alt="Delicious" src="./static/i/delicious-16x16.png">&nbsp;<a onclick="window.open(this.href, 'sharer');return false;" title="Delicious" href="http://del.icio.us/post?v=4&amp;noui&amp;jump=close&amp;url=http%3A//www.pycon.it/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Delicious</a>
+                <img width="16" height="16" alt="Delicious" src="./static/i/delicious-16x16.png">&nbsp;<a onclick="window.open(this.href, 'sharer');return false;" title="Delicious" href="http://del.icio.us/post?v=4&amp;noui&amp;jump=close&amp;url=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Delicious</a>
             </li>
             <li>
                 <!-- reddit.com -->
-                <img width="16" height="16" alt="Reddit" src="./static/i/reddit-16x16.png">&nbsp;<a title="Reddit" onclick="window.open(this.href, 'sharer');return false;" href="http://reddit.com/submit?url=http%3A//www.pycon.it/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Reddit</a>
+                <img width="16" height="16" alt="Reddit" src="./static/i/reddit-16x16.png">&nbsp;<a title="Reddit" onclick="window.open(this.href, 'sharer');return false;" href="http://reddit.com/submit?url=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Reddit</a>
             </li>            
         </ul>
     </div>
@@ -156,11 +156,11 @@ For information: <a href="http://www.codemotion.it/en">www.codemotion.it</a></p>
         <ul>
             <li>
                 <!-- twitter -->
-                <img width="16" height="16" alt="Twitter" src="./static/i/twitter-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Twitter" href="http://twitter.com/home?status=Become%20a%20Codemotion%20Speaker+http%3A//www.pycon.it/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Twitter</a>        
+                <img width="16" height="16" alt="Twitter" src="./static/i/twitter-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Twitter" href="http://twitter.com/home?status=Become%20a%20Codemotion%20Speaker+http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Twitter</a>        
             </li>                    
             <li>
                 <!-- friendfeed -->
-                <img width="16" height="16" alt="Friendfeed" src="./static/i/friendfeed-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Facebook" href="http://www.friendfeed.com/share?title=Become%20a%20Codemotion%20Speaker&amp;link=http%3A//www.pycon.it/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Friendfeed</a>        
+                <img width="16" height="16" alt="Friendfeed" src="./static/i/friendfeed-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Facebook" href="http://www.friendfeed.com/share?title=Become%20a%20Codemotion%20Speaker&amp;link=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Friendfeed</a>        
             </li>            
         </ul>
     </div>
@@ -169,11 +169,11 @@ For information: <a href="http://www.codemotion.it/en">www.codemotion.it</a></p>
         <ul>
             <li>
                 <!-- facebook -->
-                <img width="16" height="16" alt="Facebook" src="./static/i/facebook-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Facebook" href="http://www.facebook.com/share.php?u=http%3A//www.pycon.it/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Facebook</a>        
+                <img width="16" height="16" alt="Facebook" src="./static/i/facebook-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Facebook" href="http://www.facebook.com/share.php?u=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Facebook</a>        
             </li>
             <li>
                 <!-- stumbleupon -->
-                <img width="16" height="16" alt="StumbleUpon" src="./static/i/stumbleupon-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="StumbleUpon" href="http://www.stumbleupon.com/submit?url=http%3A//www.pycon.it/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">StumbleUpon</a>        
+                <img width="16" height="16" alt="StumbleUpon" src="./static/i/stumbleupon-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="StumbleUpon" href="http://www.stumbleupon.com/submit?url=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">StumbleUpon</a>        
             </li>
         </ul>
     </div>
@@ -182,11 +182,11 @@ For information: <a href="http://www.codemotion.it/en">www.codemotion.it</a></p>
         <ul>
             <li>
                 <!-- digg.com -->
-                <img width="16" height="16" alt="digg" src="./static/i/digg-this-16x16.png">&nbsp;<a title="digg" onclick="window.open(this.href, 'sharer');return false;" href="http://digg.com/submit?phase=2&amp;url=http%3A//www.pycon.it/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Digg this</a>
+                <img width="16" height="16" alt="digg" src="./static/i/digg-this-16x16.png">&nbsp;<a title="digg" onclick="window.open(this.href, 'sharer');return false;" href="http://digg.com/submit?phase=2&amp;url=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Digg this</a>
             </li>        
             <li>
                 <!-- newsvine -->
-                <img width="16" height="16" alt="Newsvine" src="./static/i/newsvine-16x16.png">&nbsp;<a title="Newsvine" onclick="window.open(this.href, 'sharer');return false;" href="http://www.newsvine.com/_tools/seed&amp;save?u=http%3A//www.pycon.it/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;h=Become%20a%20Codemotion%20Speaker">Newsvine</a>            
+                <img width="16" height="16" alt="Newsvine" src="./static/i/newsvine-16x16.png">&nbsp;<a title="Newsvine" onclick="window.open(this.href, 'sharer');return false;" href="http://www.newsvine.com/_tools/seed&amp;save?u=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;h=Become%20a%20Codemotion%20Speaker">Newsvine</a>            
             </li>
         </ul>
     </div>
@@ -234,7 +234,7 @@ For information: <a href="http://www.codemotion.it/en">www.codemotion.it</a></p>
                 
                 <div class="metadata">
                     
-                        <span><a class="reply-comment" href="#">Reply</a> | </span><strong><a rel="nofollow" href="http://pycon.it/">C8E</a></strong>,&nbsp;
+                        <span><a class="reply-comment" href="#">Reply</a> | </span><strong><a rel="nofollow" href="http://euroython.eu/">C8E</a></strong>,&nbsp;
                     
                         <span class="date">04 aprile 2010</span>&nbsp;<a href="#comment-80" title="Permalink a questo commento" class="permalink">#</a>
                 </div>

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,7 +1,7 @@
 from fabric.api import env
 
 env.user = 'pyconwww'
-env.hosts = ['pycon.it']
+env.hosts = ['euroython.eu']
 env.forward_agent = True
 
 import sys
@@ -78,10 +78,10 @@ class PyconLayout(object):
         self.project_name = project_name
 
     def working_copy(self):
-        return '/srv/pycon.it/sites/{}/'.format(self.project_name)
+        return '/srv/euroython.eu/sites/{}/'.format(self.project_name)
 
     def virtualenv(self):
-        return '/srv/pycon.it/virtualenvs/{}/'.format(self.project_name)
+        return '/srv/euroython.eu/virtualenvs/{}/'.format(self.project_name)
 
 class ProcessManager(object):
     def __init__(self, upstart_name):

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -205,7 +205,7 @@ msgid "Email already registered"
 msgstr ""
 
 #: p3/forms.py:478
-msgid "I want to receive a few selected job offers through PyCon."
+msgid "I want to receive a few selected job offers through EuroPython."
 msgstr ""
 
 #: p3/forms.py:479
@@ -531,7 +531,7 @@ msgstr ""
 
 #: p3/templates/assopy/profile.html:88
 msgid ""
-"Cannot remove the requested account, please contact info@pycon.it for "
+"Cannot remove the requested account, please contact info@euroython.eu for "
 "assistance"
 msgstr ""
 
@@ -737,11 +737,11 @@ msgstr "All the deadlines &rarr;"
 #: p3/templates/cms/index.html:55
 msgid ""
 "Following the great success of the last year we will waiting for you at "
-"PyCon Italy, the biggest national conference in Europe dedicated to the "
+"EuroPython, the biggest national conference in Europe dedicated to the "
 "Python programming language."
 msgstr ""
 "Following the great success of the last year we will waiting for you at "
-"PyCon Italy, the biggest national conference in Europe dedicated to the "
+"EuroPython, the biggest national conference in Europe dedicated to the "
 "Python programming language."
 
 #: p3/templates/cms/index.html:63
@@ -811,7 +811,7 @@ msgid "Become a sponsor"
 msgstr ""
 
 #: p3/templates/cms/p5_homepage.html:98
-msgid "PyCon blog"
+msgid "EuroPython blog"
 msgstr ""
 
 #: p3/templates/conference/genro_wrapper.html:6
@@ -825,7 +825,7 @@ msgstr ""
 "If you have any problems please contact us via <a "
 "onclick=\"habla_window.show(); habla_window.expand()\" href=\"#\">chat</a> "
 "or drop a line to <a "
-"href=\"mailto:gestionale@pycon.it\">gestionale@pycon.it</a>"
+"href=\"mailto:gestionale@euroython.eu\">gestionale@euroython.eu</a>"
 
 #: p3/templates/conference/profile.html:25
 msgid "It’s you!"
@@ -883,7 +883,7 @@ msgstr ""
 
 #: p3/templates/conference/profile_visibility_form.html:15
 msgid ""
-"Your profile is <b>publicly visible</b> because you are a PyCon speaker."
+"Your profile is <b>publicly visible</b> because you are a EuroPython speaker."
 msgstr ""
 
 #: p3/templates/conference/profile_visibility_form.html:17
@@ -928,7 +928,7 @@ msgstr ""
 #: p3/templates/conference/talk.html:25
 #: p3/templates/microblog/post_detail.html:21
 msgid "Lo staff sta controllando il tuo commento, a breve verrà pubblicato."
-msgstr "PyCon staff is reviewing you comment, shortly will be published"
+msgstr "EuroPython staff is reviewing you comment, shortly will be published"
 
 #: p3/templates/conference/talk.html:34
 msgid "Per favore verifica il captcha."
@@ -1080,8 +1080,8 @@ msgid "All the deadlines"
 msgstr "All the deadlines &rarr;"
 
 #: p3/templates/django_cms/p5_homepage.html:116
-msgid "Scopri PyCon Italia"
-msgstr "Discover PyCon Italy"
+msgid "Scopri EuroPython Italia"
+msgstr "Discover EuroPython"
 
 #: p3/templates/django_cms/p5_homepage.html:123
 msgid "Talk"
@@ -1129,7 +1129,7 @@ msgid "Eventi sociali"
 msgstr "Social events"
 
 #: p3/templates/django_cms/p5_homepage.html:171
-msgid "Ribollita, bistecca e vino: che PyCon è senza una bella mangiata?"
+msgid "Ribollita, bistecca e vino: che EuroPython è senza una bella mangiata?"
 msgstr "Ribollita, steak and wine: what's Pycon without a binge?"
 
 #: p3/templates/django_cms/p5_homepage.html:194
@@ -1271,7 +1271,7 @@ msgstr ""
 #: p3/templates/p3/box_newsletter.html:5
 msgid ""
 "If you want to stay updated with news about thie conference, sign-up to the "
-"official low-traffic PyCon mailing-list:"
+"official low-traffic EuroPython mailing-list:"
 msgstr ""
 
 #: p3/templates/p3/box_newsletter.html:8
@@ -1370,7 +1370,7 @@ msgstr ""
 
 #: p3/templates/p3/schedule_list.html:8
 #, fuzzy
-msgid "PyCon schedule"
+msgid "EuroPython schedule"
 msgstr "Personal website"
 
 #: p3/templates/p3/sprint_submission.html:4
@@ -1379,7 +1379,7 @@ msgstr ""
 
 #: p3/templates/p3/sprints.html:56
 msgid ""
-"Cannot save the form.\\nUse the web chat, or contact info@pycon.it, for "
+"Cannot save the form.\\nUse the web chat, or contact info@euroython.eu, for "
 "assistance."
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 
 #: p3/templates/p3/tickets.html:83
 msgid ""
-"Cannot save the ticket.\\nUse the web chat, or contact info@pycon.it, for "
+"Cannot save the ticket.\\nUse the web chat, or contact info@euroython.eu, for "
 "assistance."
 msgstr ""
 
@@ -1607,7 +1607,7 @@ msgid "Change to language:"
 msgstr ""
 
 #: p3/templates/registration/login.html:9
-msgid "Log into PyCon"
+msgid "Log into EuroPython"
 msgstr ""
 
 #: p3/templates/registration/login.html:12
@@ -1842,7 +1842,7 @@ msgstr ""
 
 #~ msgid "saluto di guido in homepage"
 #~ msgstr ""
-#~ "This year's PyCon Italy will have an exceptional guest in <b><a "
+#~ "This year's EuroPython will have an exceptional guest in <b><a "
 #~ "href=\"http://en.wikipedia.org/wiki/Guido_van_Rossum\">Guido van "
 #~ "Rossum</a></b>, author of the language, who will give a Keynote about the "
 #~ "latest developments of the language."

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -198,7 +198,7 @@ msgid "Email already registered"
 msgstr ""
 
 #: p3/forms.py:500
-msgid "I want to receive a few selected job offers through PyCon."
+msgid "I want to receive a few selected job offers through EuroPython."
 msgstr ""
 
 #: p3/forms.py:501
@@ -559,7 +559,7 @@ msgstr ""
 
 #: p3/templates/assopy/profile.html:82
 msgid ""
-"Cannot remove the requested account, please contact info@pycon.it for "
+"Cannot remove the requested account, please contact info@euroython.eu for "
 "assistance"
 msgstr ""
 
@@ -872,7 +872,7 @@ msgstr ""
 
 #: p3/templates/conference/profile_visibility_form.html:15
 msgid ""
-"Your profile is <b>publicly visible</b> because you are a PyCon speaker."
+"Your profile is <b>publicly visible</b> because you are a EuroPython speaker."
 msgstr ""
 
 #: p3/templates/conference/profile_visibility_form.html:17
@@ -1090,7 +1090,7 @@ msgid "Become a sponsor"
 msgstr ""
 
 #: p3/templates/django_cms/p5_homepage.html:109
-msgid "Scopri PyCon Italia"
+msgid "Scopri EuroPython Italia"
 msgstr ""
 
 #: p3/templates/django_cms/p5_homepage.html:116
@@ -1137,7 +1137,7 @@ msgid "Eventi sociali"
 msgstr ""
 
 #: p3/templates/django_cms/p5_homepage.html:164
-msgid "Ribollita, bistecca e vino: che PyCon è senza una bella mangiata?"
+msgid "Ribollita, bistecca e vino: che EuroPython è senza una bella mangiata?"
 msgstr ""
 
 #: p3/templates/django_cms/p5_homepage.html:184
@@ -1288,7 +1288,7 @@ msgstr ""
 #: p3/templates/p3/box_newsletter.html:5
 msgid ""
 "If you want to stay updated with news about thie conference, sign-up to the "
-"official low-traffic PyCon mailing-list:"
+"official low-traffic EuroPython mailing-list:"
 msgstr ""
 
 #: p3/templates/p3/box_newsletter.html:8
@@ -1429,7 +1429,7 @@ msgid "Schedule"
 msgstr ""
 
 #: p3/templates/p3/schedule_list.html:8
-msgid "PyCon schedule"
+msgid "EuroPython schedule"
 msgstr ""
 
 #: p3/templates/p3/sprint_submission.html:4
@@ -1438,7 +1438,7 @@ msgstr ""
 
 #: p3/templates/p3/sprints.html:56
 msgid ""
-"Cannot save the form.\\nUse the web chat, or contact info@pycon.it, for "
+"Cannot save the form.\\nUse the web chat, or contact info@euroython.eu, for "
 "assistance."
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 
 #: p3/templates/p3/tickets.html:83
 msgid ""
-"Cannot save the ticket.\\nUse the web chat, or contact info@pycon.it, for "
+"Cannot save the ticket.\\nUse the web chat, or contact info@euroython.eu, for "
 "assistance."
 msgstr ""
 
@@ -1664,7 +1664,7 @@ msgid "Change to language:"
 msgstr ""
 
 #: p3/templates/registration/login.html:9
-msgid "Log into PyCon"
+msgid "Log into EuroPython"
 msgstr ""
 
 #: p3/templates/registration/login.html:17

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -225,7 +225,7 @@ msgid "Email already registered"
 msgstr ""
 
 #: p3/forms.py:478
-msgid "I want to receive a few selected job offers through PyCon."
+msgid "I want to receive a few selected job offers through EuroPython."
 msgstr ""
 
 #: p3/forms.py:479
@@ -489,7 +489,7 @@ msgid ""
 "Partecipate in <a href=\"%(url)s\">Find out who's coming</a>: let people "
 "know that you will be coming to this conference."
 msgstr ""
-"Fai sapere a tutti che verrai a PyCon: compila il tuo profilo e pubblicalo "
+"Fai sapere a tutti che verrai a EuroPython: compila il tuo profilo e pubblicalo "
 "nella sezione \"<a href=\"%(url)s\">Scopri chi viene</a>"
 
 #: p3/templates/assopy/profile.html:14
@@ -566,7 +566,7 @@ msgstr ""
 
 #: p3/templates/assopy/profile.html:88
 msgid ""
-"Cannot remove the requested account, please contact info@pycon.it for "
+"Cannot remove the requested account, please contact info@euroython.eu for "
 "assistance"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr "Vedi tutte le scadenze &rarr;"
 #: p3/templates/cms/index.html:55
 msgid ""
 "Following the great success of the last year we will waiting for you at "
-"PyCon Italy, the biggest national conference in Europe dedicated to the "
+"EuroPython, the biggest national conference in Europe dedicated to the "
 "Python programming language."
 msgstr ""
 "Dopo il grande successo dell'ultima edizione, anche quest'anno vi aspettiamo"
@@ -880,8 +880,8 @@ msgid "Become a sponsor"
 msgstr "Diventa uno sponsor"
 
 #: p3/templates/cms/p5_homepage.html:98
-msgid "PyCon blog"
-msgstr "Blog di PyCon"
+msgid "EuroPython blog"
+msgstr "Blog di EuroPython"
 
 #: p3/templates/conference/genro_wrapper.html:6
 msgid "genro-account"
@@ -892,7 +892,7 @@ msgid "genro-problem"
 msgstr ""
 "Se hai problemi contattaci in <a onclick=\"habla_window.show(); "
 "habla_window.expand()\" href=\"#\">chat</a> o scrivi a <a "
-"href=\"mailto:gestionale@pycon.it\">gestionale@pycon.it</a>"
+"href=\"mailto:gestionale@euroython.eu\">gestionale@euroython.eu</a>"
 
 #: p3/templates/conference/profile.html:25
 msgid "It’s you!"
@@ -953,10 +953,10 @@ msgstr ""
 
 #: p3/templates/conference/profile_visibility_form.html:15
 msgid ""
-"Your profile is <b>publicly visible</b> because you are a PyCon speaker."
+"Your profile is <b>publicly visible</b> because you are a EuroPython speaker."
 msgstr ""
 "Il tuo profilo è <b>visibile pubblicamente</b> perché sei uno speaker di "
-"PyCon Italia."
+"EuroPython Italia."
 
 #: p3/templates/conference/profile_visibility_form.html:17
 msgid "Your profile is <b>publicly visible</b>."
@@ -1154,7 +1154,7 @@ msgid "All the deadlines"
 msgstr "Vedi tutte le scadenze &rarr;"
 
 #: p3/templates/django_cms/p5_homepage.html:116
-msgid "Scopri PyCon Italia"
+msgid "Scopri EuroPython Italia"
 msgstr ""
 
 #: p3/templates/django_cms/p5_homepage.html:123
@@ -1203,7 +1203,7 @@ msgid "Eventi sociali"
 msgstr ""
 
 #: p3/templates/django_cms/p5_homepage.html:171
-msgid "Ribollita, bistecca e vino: che PyCon è senza una bella mangiata?"
+msgid "Ribollita, bistecca e vino: che EuroPython è senza una bella mangiata?"
 msgstr ""
 
 #: p3/templates/django_cms/p5_homepage.html:194
@@ -1345,10 +1345,10 @@ msgstr ""
 #: p3/templates/p3/box_newsletter.html:5
 msgid ""
 "If you want to stay updated with news about thie conference, sign-up to the "
-"official low-traffic PyCon mailing-list:"
+"official low-traffic EuroPython mailing-list:"
 msgstr ""
 "Se vuoi rimanere aggiornato sulla conferenza, iscriviti alla newsletter "
-"ufficiale a basso traffico di PyCon Italia:"
+"ufficiale a basso traffico di EuroPython Italia:"
 
 #: p3/templates/p3/box_newsletter.html:8
 msgid "Sign up"
@@ -1449,7 +1449,7 @@ msgstr ""
 
 #: p3/templates/p3/schedule_list.html:8
 #, fuzzy
-msgid "PyCon schedule"
+msgid "EuroPython schedule"
 msgstr "Sito personale"
 
 #: p3/templates/p3/sprint_submission.html:4
@@ -1458,7 +1458,7 @@ msgstr ""
 
 #: p3/templates/p3/sprints.html:56
 msgid ""
-"Cannot save the form.\\nUse the web chat, or contact info@pycon.it, for "
+"Cannot save the form.\\nUse the web chat, or contact info@euroython.eu, for "
 "assistance."
 msgstr ""
 
@@ -1510,11 +1510,11 @@ msgstr "Chiedi un rimborso"
 
 #: p3/templates/p3/tickets.html:83
 msgid ""
-"Cannot save the ticket.\\nUse the web chat, or contact info@pycon.it, for "
+"Cannot save the ticket.\\nUse the web chat, or contact info@euroython.eu, for "
 "assistance."
 msgstr ""
 "Errore nel salvataggio del biglietto. Contattaci via chat o scrivi a "
-"info@pycon.it"
+"info@euroython.eu"
 
 #: p3/templates/p3/tickets.html:135
 msgid "Please enter the name"
@@ -1691,7 +1691,7 @@ msgid "Change to language:"
 msgstr ""
 
 #: p3/templates/registration/login.html:9
-msgid "Log into PyCon"
+msgid "Log into EuroPython"
 msgstr "Effettua il login"
 
 #: p3/templates/registration/login.html:12
@@ -1822,7 +1822,7 @@ msgstr "Italiano"
 #~ msgid "Starting from"
 #~ msgstr "A partire da"
 
-#~ msgid "PyCon in English"
+#~ msgid "EuroPython in English"
 #~ msgstr "Inglese"
 
 #~ msgid "Open chat window"
@@ -1840,8 +1840,8 @@ msgstr "Italiano"
 #~ msgid "Social"
 #~ msgstr "Social media"
 
-#~ msgid "PyCon on Facebook"
-#~ msgstr "PyCon su Facebook"
+#~ msgid "EuroPython on Facebook"
+#~ msgstr "EuroPython su Facebook"
 
 #~ msgid "Follow us on twitter"
 #~ msgstr "Seguici su Twitter"
@@ -1860,7 +1860,7 @@ msgstr "Italiano"
 #~ msgstr ""
 #~ "Questa conferenza è organizzata dall'associazione no-profit Python Italia. "
 #~ "Accettiamo donazioni tramite PayPal e Carta di Credito; ogni contributo è "
-#~ "benvenuto e verrà usato esclusivamente per migliorare PyCon Italia per "
+#~ "benvenuto e verrà usato esclusivamente per migliorare EuroPython Italia per "
 #~ "tutti. Grazie!"
 
 #~ msgid "Donate now (via PayPal)"
@@ -1985,7 +1985,7 @@ msgstr "Italiano"
 
 #~ msgid "saluto di guido in homepage"
 #~ msgstr ""
-#~ "Questa edizione di PyCon Italia sarà arricchita dalla presenza di un ospite "
+#~ "Questa edizione di EuroPython Italia sarà arricchita dalla presenza di un ospite "
 #~ "d&#8217;eccezione: <b><a "
 #~ "href=\"http://it.wikipedia.org/wiki/Guido_van_Rossum\">Guido van "
 #~ "Rossum</a></b>, l&#8217;ideatore di Python, che terrà un keynote sulla "

--- a/p3/forms.py
+++ b/p3/forms.py
@@ -510,7 +510,7 @@ class P3ProfileEmailContactForm(forms.Form):
 
 
 class P3ProfileSpamControlForm(forms.ModelForm):
-    spam_recruiting = forms.BooleanField(label=_('I want to receive a few selected job offers through PyCon.'), required=False)
+    spam_recruiting = forms.BooleanField(label=_('I want to receive a few selected job offers through EuroPython.'), required=False)
     spam_user_message = forms.BooleanField(label=_('I want to receive private messages from other partecipants.'), required=False)
     spam_sms = forms.BooleanField(label=_('I want to receive SMS during the conference for main communications.'), required=False)
     class Meta:

--- a/p3/models.py
+++ b/p3/models.py
@@ -507,7 +507,7 @@ class P3Profile(models.Model):
             from_email=from_.email,
             to=[self.profile.user.email],
             headers={
-                'Sender': 'info@pycon.it',
+                'Sender': 'info@euroython.eu',
             }
         ).send()
         log.info('email from "%s" to "%s" sent', from_.email, self.profile.user.email)

--- a/p3/static/p5/stylesheets/_imports.scss
+++ b/p3/static/p5/stylesheets/_imports.scss
@@ -83,7 +83,7 @@ URL: http://stuffandnonsense.co.uk/projects/rock-hammer/
 @import "partials/navigation-responsive-nav";
 //@import "partials/navigation-responsive-breadcrumb";
 
-// Styles for specific PyCon sections
+// Styles for specific EuroPython sections
 
 @import "partials/pycon/legacy";
 @import "partials/pycon/blog";

--- a/p3/static/p6/stylesheets/_imports.scss
+++ b/p3/static/p6/stylesheets/_imports.scss
@@ -83,7 +83,7 @@ URL: http://stuffandnonsense.co.uk/projects/rock-hammer/
 @import "partials/navigation-responsive-nav";
 //@import "partials/navigation-responsive-breadcrumb";
 
-// Styles for specific PyCon sections
+// Styles for specific EuroPython sections
 
 @import "partials/pycon/legacy";
 @import "partials/pycon/blog";

--- a/p3/static/p6/stylesheets/all.css
+++ b/p3/static/p6/stylesheets/all.css
@@ -52,11 +52,11 @@ body { margin: 0; padding: 0; width: 100%; background-color: transparent; font-f
 .media-body { text-align: center; }
 .media-body h3 { padding-top: 5px; }
 
-.learn-with-pycon { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
-.learn-with-pycon a:hover { text-decoration: none; }
-.learn-with-pycon p { text-align: center; color: #555555; }
-.learn-with-pycon h2 { margin: 0 0 0.5em 0; }
-.learn-with-pycon h4 { color: #555555; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
+.learn-with-europython { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
+.learn-with-europython a:hover { text-decoration: none; }
+.learn-with-europython p { text-align: center; color: #555555; }
+.learn-with-europython h2 { margin: 0 0 0.5em 0; }
+.learn-with-europython h4 { color: #555555; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
 
 .learn-icon, .subcommunities .subcommunity-container { background-color: white; border-radius: 50%; width: 100px; height: 100px; border: 5px solid #E5781E; margin: 0 auto; margin-bottom: 20px; margin-top: 15px; padding: 21px; }
 
@@ -76,7 +76,7 @@ footer table { margin: 0 auto; }
 
 #navigation-toggle { border-bottom: 5px solid #E5781E; }
 
-header { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; }
+header { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; }
 
 .quote-section { background: #555; color: white; }
 .quote-section q { font-size: 30px; font-size: 3rem; line-height: 1.2; font-weight: 500; text-transform: uppercase; margin-bottom: 30px; display: block; }

--- a/p3/static/p6/stylesheets/lte-ie8.css
+++ b/p3/static/p6/stylesheets/lte-ie8.css
@@ -52,11 +52,11 @@ body { margin: 0; padding: 0; width: 100%; background-color: transparent; font-f
 .media-body { text-align: center; }
 .media-body h3 { padding-top: 5px; }
 
-.learn-with-pycon { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
-.learn-with-pycon a:hover { text-decoration: none; }
-.learn-with-pycon p { text-align: center; color: #555555; }
-.learn-with-pycon h2 { margin: 0 0 0.5em 0; }
-.learn-with-pycon h4 { color: #555555; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
+.learn-with-europython { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; background-position: center top; background-repeat: no-repeat; background-attachment: fixed; }
+.learn-with-europython a:hover { text-decoration: none; }
+.learn-with-europython p { text-align: center; color: #555555; }
+.learn-with-europython h2 { margin: 0 0 0.5em 0; }
+.learn-with-europython h4 { color: #555555; font-weight: 600; font-size: 32px; font-size: 3.2rem; margin-bottom: 0; }
 
 .learn-icon, .subcommunities .subcommunity-container { background-color: white; border-radius: 50%; width: 100px; height: 100px; border: 5px solid #e61f4b; margin: 0 auto; margin-bottom: 20px; margin-top: 15px; padding: 21px; }
 
@@ -76,7 +76,7 @@ footer table { margin: 0 auto; }
 
 #navigation-toggle { border-bottom: 5px solid #e61f4b; }
 
-header { background-image: url("../images/bg-learn-with-pycon.jpg"); background-size: cover; }
+header { background-image: url("../images/bg-learn-with-europython.jpg"); background-size: cover; }
 
 .quote-section { background: #555; color: white; }
 .quote-section q { font-size: 30px; font-size: 3rem; line-height: 1.2; font-weight: 500; text-transform: uppercase; margin-bottom: 30px; display: block; }

--- a/p3/static/p6/stylesheets/partials/_site.scss
+++ b/p3/static/p6/stylesheets/partials/_site.scss
@@ -160,8 +160,8 @@ body {
     }
 }
 
-.learn-with-pycon {
-    background-image: url("../images/bg-learn-with-pycon.jpg");
+.learn-with-europython {
+    background-image: url("../images/bg-learn-with-europython.jpg");
     background-size: cover;
     background-position: center top;
     background-repeat: no-repeat;
@@ -257,7 +257,7 @@ footer {
 }
 
 header {
-    background-image: url("../images/bg-learn-with-pycon.jpg");
+    background-image: url("../images/bg-learn-with-europython.jpg");
     background-size: cover;
 }
 

--- a/p3/templates/404.html
+++ b/p3/templates/404.html
@@ -21,7 +21,7 @@
             <li>Our page about<a href="/sponsor/">sponsorship opportunities</a>;
             </li>
             <li><a href="/faq/">Frequently asked questions</a> (F.A.Q.);</li>
-            <li>... or get back to the<a href="/">PyCon Home Page</a></li>
+            <li>... or get back to the<a href="/">EuroPython Home Page</a></li>
         </ul>
 
     </div> <!-- /grid -->

--- a/p3/templates/500.html
+++ b/p3/templates/500.html
@@ -45,7 +45,7 @@ Abandon all hope - Ye Who Enter Here
 <hr />        
 <p>While you are enjoying a fine piece of Italian art, we are trying to find the bug that had caused the display of this page.</p>
 <hr />    
-<p>The <a href="http://pycon.it/">PyCon</a> team &lt;<a href="mailto:info@pycon.it">info@pycon.it</a>&gt;</p>
+<p>The <a href="http://euroython.eu/">EuroPython</a> team &lt;<a href="mailto:info@euroython.eu">info@euroython.eu</a>&gt;</p>
 </div><!-- /wrapper -->
 </body>
 </html>

--- a/p3/templates/assopy/bank_feedback_ok.html
+++ b/p3/templates/assopy/bank_feedback_ok.html
@@ -11,7 +11,7 @@
         {% url "assopy-tickets" as u %}
         {% with order.code as ocode %}
             <p>
-            {% blocktrans with url="mailto:info@pycon.it?subject="|add:ocode code=ocode %}
+            {% blocktrans with url="mailto:info@euroython.eu?subject="|add:ocode code=ocode %}
             If you don't receive this email please check yout spam folder and <a href="{{ url }}">write to us</a> specifying your order number: <b>{{ code }}</b>
             {% endblocktrans %}
             </p>

--- a/p3/templates/assopy/paypal_feedback_ok.html
+++ b/p3/templates/assopy/paypal_feedback_ok.html
@@ -14,7 +14,7 @@
         {% if not ocomplete %}
         <h1>{% trans "Waiting for Paypal response..." %}</h1>
         <div class="page-summary" role="contentinfo">
-            <p>{% blocktrans with code=order.code url="mailto:info@pycon.it" %}
+            <p>{% blocktrans with code=order.code url="mailto:info@euroython.eu" %}
             Are you waiting for too long? <a href="{{ url }}">Write to us</a> specifying your order number {{ code }}
             {% endblocktrans %}</p>
         </div>

--- a/p3/templates/assopy/profile.html
+++ b/p3/templates/assopy/profile.html
@@ -79,7 +79,7 @@
                                         parent.remove();
                                     },
                                     error: function(xhr, status, error) {
-                                        alert('{% trans "Cannot remove the requested account, please contact info@pycon.it for assistance" %}');
+                                        alert('{% trans "Cannot remove the requested account, please contact info@euroython.eu for assistance" %}');
                                     }
                                 });
                             });

--- a/p3/templates/conference/ajax/voting.html
+++ b/p3/templates/conference/ajax/voting.html
@@ -126,8 +126,8 @@
             var tweet = 'Just voted ' + vote + '/10 "' + title + '" by ' + speaker + ' #europython';
             RPXNOW.loadAndRun(['Social'], function () {
                 var activity = new RPXNOW.Social.Activity('Share your vote', tweet, url);
-                activity.setTitle('PyCon - Community voting');
-                activity.setDescription('Community voting allows all PyCon attendees to take part in the voting process, which ultimately decides which of the talks submitted during the Call For Papers will become part of the schedule.');
+                activity.setTitle('EuroPython - Community voting');
+                activity.setDescription('Community voting allows all EuroPython attendees to take part in the voting process, which ultimately decides which of the talks submitted during the Call For Papers will become part of the schedule.');
                 {% url "conference-voting" as u %}
                 activity.addActionLink('Vote a talk', '{{ u|full_url }}');
                 var media = new RPXNOW.Social.ImageMediaCollection();

--- a/p3/templates/conference/profile_visibility_form.html
+++ b/p3/templates/conference/profile_visibility_form.html
@@ -12,7 +12,7 @@
                 {% endif %}
                 {% if profile_data.visibility == "p" %}
                     {% if profile_data.talks.accepted.all %}
-                    <span class="profile-open"><i class="fa fa-globe"></i> {% trans "Your profile is <b>publicly visible</b> because you are a PyCon speaker." %}</span>
+                    <span class="profile-open"><i class="fa fa-globe"></i> {% trans "Your profile is <b>publicly visible</b> because you are a EuroPython speaker." %}</span>
                     {% else %}
                     <span class="profile-open"><i class="fa fa-globe"></i> {% trans "Your profile is <b>publicly visible</b>." %}</span>
                     {% endif %}

--- a/p3/templates/django_cms/p5_homepage.html
+++ b/p3/templates/django_cms/p5_homepage.html
@@ -103,10 +103,10 @@
         </div>
     </section>
 
-    <section class="learn-with-pycon">
+    <section class="learn-with-europython">
         <div class="grid-container">
             <div class="grid-100">
-                <h2 class="border-title">{% trans "Scopri PyCon Italia" %}</h2>
+                <h2 class="border-title">{% trans "Discover EuroPython" %}</h2>
             </div>
             <div class="grid-33">
                 <a href="#">
@@ -114,7 +114,7 @@
                         <img src="{% static 'p6/images/talk.svg' %}">
                     </div>
                     <h4>{% trans "Talk" %}</h4>
-                    <p>{% trans "3 tracce parallele di talk per ascoltare e scoprire" %}
+                    <p>{% trans "Enjoy 5 parallel tracks, over 100 talks, plenty of hallway sessions" %}
                 </a>
             </div>
             <div class="grid-33">
@@ -123,7 +123,7 @@
                         <img src="{% static 'p6/images/training.svg' %}" />
                     </div>
                     <h4>{% trans "Training" %}</h4>
-                    <p>{% trans "Sessioni di 4 ore, con le mani sulla tastieraaa: impara l'arte e mettila da parte" %}
+                    <p>{% trans "Professional trainers to teach you Python and how to use it effectively" %}
                 </a>
             </div>
             <div class="grid-33">
@@ -132,7 +132,7 @@
                         <img src="{% static 'p6/images/helpdesk.svg' %}" />
                     </div>
                     <h4>{% trans "Helpdesk" %}</h4>
-                    <p>{% trans "Risolvi un problema: fissa un appuntamento e parla con i nostri esperti" %}
+                    <p>{% trans "Get help for solving your problems directly from the experts" %}
                 </a>
             </div>
 
@@ -142,8 +142,8 @@
                     <div class="learn-icon">
                         <img src="{% static 'p6/images/scopri_chi_viene.svg' %}" />
                     </div>
-                    <h4>{% trans "Scopri chi viene" %}</h4>
-                    <p>{% trans "Guarda chi ha già comprato un biglietto, contattalo, organizza un incontro" %}
+                    <h4>{% trans "Who's coming" %}</h4>
+                    <p>{% trans "Check the public profiles and arrange meetings" %}
                 </a>
             </div>
             <div class="grid-33">
@@ -152,7 +152,7 @@
                         <img src="{% static 'p6/images/recruiting.svg' %}" />
                     </div>
                     <h4>{% trans "Recruiting" %}</h4>
-                    <p>{% trans "Cerchi lavoro su Python? Partecipa alle nostre sessioni dedicate" %}
+                    <p>{% trans "Find excellent Python jobs" %}
                 </a>
             </div>
             <div class="grid-33">
@@ -160,8 +160,8 @@
                     <div class="learn-icon">
                         <img src="{% static 'p6/images/eventi_sociali.svg' %}" />
                     </div>
-                    <h4>{% trans "Eventi sociali" %}</h4>
-                    <p>{% trans "Ribollita, bistecca e vino: che PyCon è senza una bella mangiata?" %}
+                    <h4>{% trans "Social Events" %}</h4>
+                    <p>{% trans "Enjoy lounge events, dinners, boar trips, etc." %}
                 </a>
             </div>
         </div>
@@ -181,7 +181,7 @@
     <div class="grid-container">
         {% post_list count=3 as posts %}
         <div class="grid-100">
-            <h2 class="border-title">{% trans "Ultimi post dal blog" %}</h2>
+            <h2 class="border-title">{% trans "Watch our blog for updates" %}</h2>
         </div>
         {% for post in posts %}
             {% get_post_data post.id as data %}

--- a/p3/templates/p3/base.html
+++ b/p3/templates/p3/base.html
@@ -87,12 +87,10 @@
     <script type="text/javascript" src="{% url "p3-map-js" %}"></script>
     {% block EXTRA_HEAD %}{% endblock %}
 
-    <!-- verification for YouTube channel -->
-    <meta name="google-site-verification" content="kBsSy1heDIyy-W34t57N5-RsOKonmK54u7zn0mC8mv8" />
     {% render_block "css" %}
     {% block OPENGRAPH %}
-    <meta property="og:image" content="https://www.pycon.it/media/filer_public/68/44/6844ea4f-0676-4cfc-a6e7-11559dc95639/pycon6_150.png" />
-    <meta property="fb:admins" content="789244177" />
+    <!--<meta property="og:image" content="https://www.euroython.eu/og-image.png" />-->
+    <!--<meta property="fb:admins" content="789244177" />-->
     {% endblock %}
 </head>
 <body id="{% block BODY_ID %}{% endblock %}" class="{% block body-class %}content-tpl{% endblock %}">
@@ -176,7 +174,7 @@
 
 <div class="copyright">
 
-    <p>&copy; 2007&ndash;2014 <a href="/python-italia/">Python Italia</a> with <a href="http://creativecommons.org/licenses/by-nd/3.0/">some rights reserved</a>.</p>
+    <p>&copy; 2015 <a href="http://www.europython-society.org/">EuroPython Society (EPS)</a> | <a href="http://www.europython-society.org/trademarks">Trademarks</a> | <a href="/imprint">Imprint</a> | <a href="/coc">CoC</a> | <a href="/imprint">Photo References</a></p>
 </div>
 
 </footer>
@@ -195,7 +193,8 @@
     </script>
     <script type="text/javascript">
         try {
-            var pageTracker = _gat._getTracker("UA-1860245-1");
+            // TODO: Adjust tracker ID
+            var pageTracker = _gat._getTracker("UA-xxxxxxx-x");
             pageTracker._trackPageview();
         } catch(err) {
         }
@@ -223,8 +222,7 @@
         });
     </script>
     <script type="text/javascript">
-
-        $('.learn-with-pycon').parallax({
+        $('.learn-with-europython').parallax({
             speed : 0.3
         });
     </script>

--- a/p3/templates/p3/box_googlemaps.html
+++ b/p3/templates/p3/box_googlemaps.html
@@ -1,5 +1,5 @@
 <div class="slot slot-map">
-    <h4>PyCon Map</h4>
+    <h4>EuroPython Map</h4>
     <div id="mini-map-{{ rand }}" class="mini-map" style="width: 100%; height: 250px"></div>
     <script type="text/javascript">
         $(document).ready(function() { initGMAP('mini-map-{{ rand }}', [ {{ what|safe }} ], {{ zoom }}); });

--- a/p3/templates/p3/box_newsletter.html
+++ b/p3/templates/p3/box_newsletter.html
@@ -2,7 +2,7 @@
 {% if NEWSLETTER_SUBSCRIBE_URL %}
 <div class="slot slot-newsletter">
     <h4>{% trans "Newsletter" %}</h4>
-    <p>{% trans "If you want to stay updated with news about thie conference, sign-up to the official low-traffic PyCon mailing-list:" %}</p>
+    <p>{% trans "If you want to stay updated with news about thie conference, sign-up to the official low-traffic EuroPython mailing-list:" %}</p>
     <form action="{{ NEWSLETTER_SUBSCRIBE_URL }}" method="post">
         <label><input placeholder="Your email address" type="text" name="email" value="" size="20" /></label>
         <button type="submit" class="btn btn-small" name="" value="">{% trans "Sign up" %}</button>

--- a/p3/templates/p3/box_pycon_italia.html
+++ b/p3/templates/p3/box_pycon_italia.html
@@ -1,4 +1,4 @@
 <div class="slot slot-python-italia">
     <h4>Python Italia APS</h4>
-    <p>Associazione <i>non-profit</i> che ha come obiettivo la promozione e la diffusione del linguaggio libero "Python" in Italia, promuove le proprie iniziative grazie agli introiti derivanti dalla vendita dei biglietti di ingresso al PyCon.it e dalla collaborazione con aziende sponsor.</p>
+    <p>Associazione <i>non-profit</i> che ha come obiettivo la promozione e la diffusione del linguaggio libero "Python" in Italia, promuove le proprie iniziative grazie agli introiti derivanti dalla vendita dei biglietti di ingresso al EuroPython.it e dalla collaborazione con aziende sponsor.</p>
 </div>

--- a/p3/templates/p3/schedule_list.html
+++ b/p3/templates/p3/schedule_list.html
@@ -5,7 +5,7 @@
     <div class="grid-container">
     <div class="grid-100">
 
-    <h1>{% block CONTENT_TITLE %}{% trans 'PyCon schedule' %}{% endblock %}</h1>
+    <h1>{% block CONTENT_TITLE %}{% trans 'EuroPython schedule' %}{% endblock %}</h1>
     <div class="conference-schedules list"  data-conference="{{ CONFERENCE }}">
     {% schedules_data sids as schedules %}
     {% for sid, timet in timetables %}

--- a/p3/templates/p3/sprints.html
+++ b/p3/templates/p3/sprints.html
@@ -53,7 +53,7 @@
                 setup_trigger_overlay($('.trigger-overlay', wrapper));
             },
             error: function() {
-                alert('{% trans "Cannot save the form.\nUse the web chat, or contact info@pycon.it, for assistance." %}');
+                alert('{% trans "Cannot save the form.\nUse the web chat, or contact info@euroython.eu, for assistance." %}');
             }
         });
     });

--- a/p3/templates/p3/tickets.html
+++ b/p3/templates/p3/tickets.html
@@ -80,7 +80,7 @@
         }
     });
     function _error() {
-        {% trans "Cannot save the ticket.\nUse the web chat, or contact info@pycon.it, for assistance." as t_error %}
+        {% trans "Cannot save the ticket.\nUse the web chat, or contact info@euroython.eu, for assistance." as t_error %}
         alert("{{ t_error|escapejs }}");
     }
     function _success(message, container) {

--- a/p3/templates/post_list.html
+++ b/p3/templates/post_list.html
@@ -4,7 +4,7 @@
 {% block PAGE_ENTRY %}
     <div id="page">
         <div id="page-title">
-            <h1>PyCon Italia Blog</h1>
+            <h1>EuroPython Blog</h1>
         </div>
         <ul class="archive">
         {% for post in object_list %}

--- a/p3/templates/registration/login.html
+++ b/p3/templates/registration/login.html
@@ -6,7 +6,7 @@
 <section>
     <div class="grid-container">
     <div class="grid-100">
-        <h1>{% trans "Log into PyCon" %}</h1>
+        <h1>{% trans "Log into EuroPython" %}</h1>
     </div>
     <div class="grid-50">
         <h2>{% trans "By using one of your existing web accounts" %}</h2>

--- a/p3/utils.py
+++ b/p3/utils.py
@@ -152,7 +152,7 @@ def conference2ical(conf, user=None, abstract=False):
         elif component == 'event':
             eid = data['uid']
             data['uid'] = settings.DEFAULT_URL_PREFIX + '/p3/event/' + str(data['uid'])
-            data['organizer'] = ('mailto:info@pycon.it', {'CN': 'Python Italia'})
+            data['organizer'] = ('mailto:info@euroython.eu', {'CN': 'EuroPython'})
             if hotel:
                 data['coordinates'] = [hotel.lat, hotel.lng]
             if not isinstance(data['summary'], tuple):

--- a/pycon/settings.py
+++ b/pycon/settings.py
@@ -49,7 +49,7 @@ else:
 }
 
 SERVER_EMAIL = 'wtf@python.it'
-DEFAULT_FROM_EMAIL = 'info@pycon.it'
+DEFAULT_FROM_EMAIL = 'info@euroython.eu'
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -131,6 +131,9 @@ TEMPLATE_LOADERS = (
 
 from django.conf import global_settings
 
+#
+# XXX THESE SHOULD GO INTO THE OS.ENVIRON !
+#
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = '672999261902-vi58eghq2jjf6ai1fio1a6t7d7q1c76n.apps.googleusercontent.com'
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = '0OnGot_90JjGeppVAKIghPgU'
 LOGIN_REDIRECT_URL = '/'
@@ -403,10 +406,14 @@ CKEDITOR_SETTINGS = {
     'extraPlugins': 'cmsplugins',
 }
 
-MICROBLOG_LINK = 'http://dev.europython.eu'
-MICROBLOG_TITLE = 'PyconIT blog'
-MICROBLOG_DESCRIPTION = 'latest news from europython'
-MICROBLOG_DEFAULT_LANGUAGE = 'it'
+
+#
+# We're not going to use this feature for EuroPython 2015:
+#
+MICROBLOG_LINK = 'http://blog.europython.eu'
+MICROBLOG_TITLE = 'EuroPython Blog'
+MICROBLOG_DESCRIPTION = 'Latest news from EuroPython'
+MICROBLOG_DEFAULT_LANGUAGE = 'en'
 MICROBLOG_POST_LIST_PAGINATION = True
 MICROBLOG_POST_PER_PAGE = 10
 MICROBLOG_MODERATION_TYPE = 'akismet'
@@ -414,7 +421,7 @@ MICROBLOG_AKISMET_KEY = '56c34997206c'
 MICROBLOG_EMAIL_RECIPIENTS = ['pycon-organization@googlegroups.com']
 MICROBLOG_EMAIL_INTEGRATION = True
 
-MICROBLOG_TWITTER_USERNAME = 'pyconit'
+MICROBLOG_TWITTER_USERNAME = 'europython'
 MICROBLOG_TWITTER_POST_URL_MANGLER = 'microblog.utils.bitly_url'
 MICROBLOG_TWITTER_INTEGRATION = False
 
@@ -449,18 +456,21 @@ def MICROBLOG_POST_FILTER(posts, user):
 
 SESSION_COOKIE_NAME = 'p5_sessionid'
 
+#
+# XXX THESE NEED TO GO INTO OS.ENVIRON !!!
+#
 CONFERENCE_OLARK_KEY = '1751-12112149-10-1389'
 CONFERENCE_GOOGLE_MAPS = {
-    # chiave info@pycon.it per http://localhost
+    # chiave info@euroython.eu per http://localhost
     # 'key': 'ABQIAAAAaqki7uO3Z2gFXuaDbZ-9BBT2yXp_ZAY8_ufC3CFXhHIE1NvwkxSCRpOQNQwH5i15toJmp6eLWzSKPg',
-    # chiave info@pycon.it per http://pycon.it
+    # chiave info@euroython.eu per http://euroython.eu
     'key': 'ABQIAAAAaqki7uO3Z2gFXuaDbZ-9BBT8rJViP5Kd0PVV0lwN5R_47a678xQFxoY_vNcqiT-2xRPjGe6Ua3A5oQ',
-    'country': 'it',
+    'country': 'es',
 }
 
 CONFERENCE_CONFERENCE = 'ep2015'
-CONFERENCE_SEND_EMAIL_TO = [ 'pycon-organization@googlegroups.com', ]
-CONFERENCE_VOTING_DISALLOWED = 'https://www.pycon.it/voting-disallowed'
+CONFERENCE_SEND_EMAIL_TO = [ 'helpdesk@europython.eu', ]
+CONFERENCE_VOTING_DISALLOWED = 'https://www.euroython.eu/voting-disallowed'
 
 CONFERENCE_FORMS = {
     'PaperSubmission': 'p3.forms.P3SubmissionForm',
@@ -737,17 +747,20 @@ def ASSOPY_ORDERITEM_CAN_BE_REFUNDED(user, item):
     return item.order._complete
 
 
+#
+# XXX What is this AssoPy stuff ?
+#
 GENRO_BACKEND = False
 ASSOPY_VIES_WSDL_URL = None
-ASSOPY_BACKEND = 'http://assopy.pycon.it/conference/externalcall'
+ASSOPY_BACKEND = 'http://assopy.euroython.eu/conference/externalcall'
 ASSOPY_SEARCH_MISSING_USERS_ON_BACKEND = True
 ASSOPY_TICKET_PAGE = 'p3-tickets'
-ASSOPY_SEND_EMAIL_TO = ['log@pycon.it']
+ASSOPY_SEND_EMAIL_TO = ['log@euroython.eu']
 ASSOPY_REFUND_EMAIL_ADDRESS = {
-    'approve': ['info@pycon.it'],
+    'approve': ['info@euroython.eu'],
     'execute': {
         None: ['dvd@gnx.it'],
-        'bank': ['matteo@pycon.it'],
+        'bank': ['matteo@euroython.eu'],
     },
     'credit-note': ['michele.bertoldi@gmail.com'],
 }
@@ -757,18 +770,18 @@ ASSOPY_OTC_CODE_HANDLERS = {
 }
 
 DEFAULT_URL_PREFIX = 'http://dev.europython.eu'
-PINGBACK_TARGET_DOMAIN = 'www.pycon.it'
+PINGBACK_TARGET_DOMAIN = 'www.euroython.eu'
 COMMENTS_APP = 'hcomments'
 
 P3_FARES_ENABLED = lambda u: True
-P3_NEWSLETTER_SUBSCRIBE_URL = "http://groups.google.com/group/python-italia-aps/boxsubscribe"
+P3_NEWSLETTER_SUBSCRIBE_URL = "https://mail.python.org/mailman/subscribe/europython-announce"
 P3_TWITTER_USER = MICROBLOG_TWITTER_USERNAME
 P3_USER_MESSAGE_FOOTER = '''
 
-This message was sent from a participant at the conference PyconITalia.
+This message was sent from a participant at the EuroPython conference.
 Your email address is not disclosed to anyone, to stop receiving messages
 from other users you can change your privacy settings from this page:
-https://www.pycon.it/accounts/profile/
+https://www.euroython.eu/accounts/profile/
 '''
 
 TEMPLATESADMIN_EDITHOOKS = (


### PR DESCRIPTION
Change the homepage discover "buttons" to use English text.

Update the footer line to the EuroPython 2015 theme footer.

Fix the name of the background image to read "europython" instead
of "pycon" in the CSS/HTML files.

Add a few warnings for account details which should not be
in a public repo.

Fix website addresses to use "europython.eu" instead of "pycon.it".

Fix newsletter subscription address to point to europython-announce
(this doesn't fully work yet, because Mailman uses a different subscription
interface than Google groups).
