### PR TITLE
Reorder the talk editing fields

### DIFF
--- a/p3/templates/conference/talk.html
+++ b/p3/templates/conference/talk.html
@@ -111,17 +111,19 @@
                 {% if cfp %}
                 {{ form.type|form_field }}
                 {{ form.sub_community|form_field }}
-                {{ form.duration|form_field }}
                 {{ form.language|form_field }}
+                {{ form.duration|form_field }}
                 {{ form.level|form_field }}
-                {{ form.teaser_video|form_field }}
+                {% endif %}
+                {{ form.abstract|form_field }}
+                {% if cfp %}
                 {{ form.tags|form_field }}
                 {{ form.video_agreement|form_field }}
                 {{ form.slides_agreement|form_field }}
                 {% endif %}
-                {{ form.slides|form_field }}
                 <hr />
-                {{ form.abstract|form_field }}
+                {{ form.teaser_video|form_field }}
+                {{ form.slides|form_field }}
                 </fieldset>
                 <fieldset>
                     <button class="btn btn-primary" name="" value="" type="submit">{% trans "Save" %}</button>


### PR DESCRIPTION
This gives them the same order as on the CFP form.
