### PR TITLE
Move language settings to p3 settings

### DIFF
--- a/p3/forms.py
+++ b/p3/forms.py
@@ -9,6 +9,7 @@ import assopy.models as amodels
 import assopy.forms as aforms
 import conference.forms as cforms
 import conference.models as cmodels
+import conference.settings as csettings
 
 from p3 import dataaccess
 from p3 import models
@@ -19,24 +20,18 @@ import datetime
 
 ## These should really be changes in the conference package:
 
-# Talk lanuages, mapping ISO code to language
-TALK_LANGUAGES = (
-    ('en', _('English')),
-    ('es', _('Spanish')),
-    ('eu', _('Basque')),
-)
+# Talk lanuages, mapping ISO code to languageT
+TALK_LANGUAGES = getattr(settings,
+                         'CONFERENCE_TALK_LANGUAGES',
+                         # TBD: Should add TALK_LANGUAGES to conference.settings
+                         #csettings.TALK_LANGUAGES
+                         settings.LANGUAGES
+                         )
 
 # Available talk durations
-TALK_DURATION = (
-    (30, _('30 minute talk incl. Q&A')),
-    (45, _('45 minute talk incl. Q&A')),
-    (60, _('60 minute talk incl. Q&A')),
-#    (90, _('90 minute talk incl. Q&A')),
-    (150, _('2.5 hours training')),
-    (180, _('3 hours training')),
-# Not yet enabled: waiting for confirmation
-#    (240, _('4 hours helpdesk')),
-)
+TALK_DURATION = getattr(settings,
+                         'CONFERENCE_TALK_DURATION',
+                         csettings.TALK_DURATION)
 
 ###
 

--- a/p3/models.py
+++ b/p3/models.py
@@ -26,8 +26,12 @@ class P3Talk(models.Model):
     """
     Estensione del talk di conference per l'utilizzo da parte di P3
     """
-    talk = models.OneToOneField('conference.Talk', related_name='p3_talk', primary_key=True)
-    sub_community = models.CharField(max_length=20, choices=TALK_SUBCOMMUNITY, default='')
+    talk = models.OneToOneField('conference.Talk',
+                                related_name='p3_talk',
+                                primary_key=True)
+    sub_community = models.CharField(max_length=20,
+                                     choices=TALK_SUBCOMMUNITY,
+                                     default='')
 
 class SpeakerConference(models.Model):
     speaker = models.OneToOneField('conference.Speaker', related_name='p3_speaker')

--- a/pycon/settings.py
+++ b/pycon/settings.py
@@ -4,6 +4,9 @@ import os
 import os.path
 import sys
 
+#from django.utils.translation import ugettext as _
+_ = lambda x:x
+
 if os.environ.get('DEBUG') == 'False':
     DEBUG = False
 else:
@@ -73,15 +76,18 @@ TIME_ZONE = 'Europe/Madrid'
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en'
 
-ugettext = lambda s: s
+# TBD: Not sure why we have three language settings, one called
+# LANGUAGES, the other CONFERENCE_TALK_LANGUAGES and yet another
+# CMS_LANGUAGES
 LANGUAGES = (
     # disabled italian
-    #('it', ugettext('Italiano')),
-    ('es', ugettext('Spanish')),
-    ('eus', ugettext('Basque')),
-    ('en', ugettext('English')),
+    #('it', _('Italiano')),
+    ('es', _('Spanish')),
+    ('eu', _('Basque')),
+    ('en', _('English')),
 )
 
+# Site ID
 SITE_ID = 1
 
 # If you set this to False, Django will make some optimizations so as not
@@ -360,8 +366,8 @@ PAGE_TEMPLATES = (
 PAGE_UNIQUE_SLUG_REQUIRED = False
 PAGE_TAGGING = True
 PAGE_LANGUAGES = (
-    ('it-it', ugettext('Italian')),
-    ('en-us', ugettext('English')),
+    ('it-it', _('Italian')),
+    ('en-us', _('English')),
 )
 PAGE_DEFAULT_LANGUAGE = PAGE_LANGUAGES[0][0]
 PAGE_LANGUAGE_MAPPING = lambda lang: PAGE_LANGUAGES[0][0]
@@ -381,11 +387,11 @@ CMS_LANGUAGES = {
     1: [
         {
             'code': 'it',
-            'name': ugettext('Italiano'),
+            'name': _('Italiano'),
         },
         {
             'code': 'en',
-            'name': ugettext('English'),
+            'name': _('English'),
         },
     ],
     'default': {
@@ -494,6 +500,24 @@ CONFERENCE_TALKS_RANKING_FILE = SITE_DATA_ROOT + '/rankings.txt'
 CONFERENCE_ADMIN_TICKETS_STATS_EMAIL_LOG = SITE_DATA_ROOT + '/admin_ticket_emails.txt'
 CONFERENCE_ADMIN_TICKETS_STATS_EMAIL_LOAD_LIBRARY = ['p3', 'conference']
 
+# Available talk durations
+CONFERENCE_TALK_DURATION = (
+    (30, _('30 minute talk incl. Q&A')),
+    (45, _('45 minute talk incl. Q&A')),
+    (60, _('60 minute talk incl. Q&A')),
+#    (90, _('90 minute talk incl. Q&A')),
+    (150, _('2.5 hours training')),
+    (180, _('3 hours training')),
+# Not yet enabled: waiting for confirmation
+#    (240, _('4 hours helpdesk')),
+)
+
+# Talk lanuages, mapping ISO code to language
+CONFERENCE_TALK_LANGUAGES = (
+    ('en', _('English')),
+    ('es', _('Spanish')),
+    ('eu', _('Basque')),
+)
 
 def CONFERENCE_TICKETS(conf, ticket_type=None, fare_code=None):
     from p3 import models


### PR DESCRIPTION
Makes the language and talk durations configurable in the
main settings rather than having them in fixed as module
globals.

Note: Since the conference package does not know about these
settings, the Django admin will still report the hard-coded
durations.

Fixed ISO lang code for Basque: this is "eu" not "eus".
