### PR TITLE
Make the video and slides flags available in non-CFP period

### DIFF
--- a/p3/templates/conference/talk.html
+++ b/p3/templates/conference/talk.html
@@ -116,11 +116,9 @@
                 {{ form.level|form_field }}
                 {% endif %}
                 {{ form.abstract|form_field }}
-                {% if cfp %}
                 {{ form.tags|form_field }}
                 {{ form.video_agreement|form_field }}
                 {{ form.slides_agreement|form_field }}
-                {% endif %}
                 <hr />
                 {{ form.teaser_video|form_field }}
                 {{ form.slides|form_field }}


### PR DESCRIPTION
as well.

Fixes #128.
