### PR TITLE
Add missing imports to p3.models.

### DIFF
--- a/p3/models.py
+++ b/p3/models.py
@@ -11,7 +11,8 @@ from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.utils.translation import ugettext as _
 
-from conference.models import Ticket, ConferenceTaggedItem, AttendeeProfile
+from conference.models import Ticket, ConferenceTaggedItem, AttendeeProfile, \
+    TalkSpeaker, Speaker
 from taggit.managers import TaggableManager
 
 import logging

--- a/pycon/settings.py
+++ b/pycon/settings.py
@@ -395,7 +395,7 @@ CMS_LANGUAGES = {
         },
     ],
     'default': {
-        'fallbacks': ['it', 'en'],
+        'fallbacks': ['en', 'it'],
         'redirect_on_fallback': True,
         'public': True,
         'hide_untranslated': False,


### PR DESCRIPTION
Fixes #131.

Swap the order of CM languages to use 'en' first.
