### PR TITLE
Make sure the "genro" backend service is only used when enabled.

### DIFF
--- a/p3/views/__init__.py
+++ b/p3/views/__init__.py
@@ -74,7 +74,8 @@ def _assign_ticket(ticket, email):
             recipient = amodels.UserIdentity.objects.filter(email__iexact=email)[0].user.user
         except IndexError:
             recipient = None
-    if recipient is None:
+    # Look in the "genro" backend, if possible
+    if settings.GENRO_BACKEND and recipient is None:
         from assopy.clients import genro
         rid = genro.users(email)['r0']
         if rid is not None:
@@ -443,6 +444,9 @@ def genro_invoice_pdf(request, assopy_id):
     import urllib
     from assopy.clients import genro
     from assopy.models import OrderItem
+
+    if not settings.GENRO_BACKEND:
+        raise http.Http404()
 
     data = genro.invoice(assopy_id)
 

--- a/pycon/settings.py
+++ b/pycon/settings.py
@@ -802,8 +802,8 @@ def ASSOPY_ORDERITEM_CAN_BE_REFUNDED(user, item):
 #
 GENRO_BACKEND = False
 ASSOPY_VIES_WSDL_URL = None
-ASSOPY_BACKEND = 'http://assopy.euroython.eu/conference/externalcall'
-ASSOPY_SEARCH_MISSING_USERS_ON_BACKEND = True
+ASSOPY_BACKEND = 'https://assopy.euroython.eu/conference/externalcall'
+ASSOPY_SEARCH_MISSING_USERS_ON_BACKEND = False
 ASSOPY_TICKET_PAGE = 'p3-tickets'
 ASSOPY_SEND_EMAIL_TO = ['billing-log@europython.io']
 ASSOPY_REFUND_EMAIL_ADDRESS = {


### PR DESCRIPTION
Disable searching missing users on the backend and use HTTPS
for the backend URL.
