### PR TITLE
More talk submission changes

### DIFF
--- a/conference/static/conference/init.js
+++ b/conference/static/conference/init.js
@@ -140,7 +140,11 @@ function _render_tags(tags, selected) {
 
     var category_wrappers = {};
     var reverse = {};
-    for(var category in conference.tags) {
+    var tag_categories = Object.keys(conference.tags);
+    tag_categories.sort();
+
+    for(var i=0; i<tag_categories.length; i++) {
+	var category = tag_categories[i];
         // reverse map, tag -> category
         for(var ix=0; ix<conference.tags[category].length; ix++)
             reverse[conference.tags[category][ix]] = category;

--- a/conference/templatetags/conference.py
+++ b/conference/templatetags/conference.py
@@ -1322,7 +1322,7 @@ def group_tags(tags):
     groups = defaultdict(list)
     for t in tags:
         groups[t.category].append(t)
-    return groups.items()
+    return sorted(groups.items())
 
 @fancy_tag(register)
 def talk_data(tid):

--- a/p3/forms.py
+++ b/p3/forms.py
@@ -56,11 +56,11 @@ TALK_TYPE_FORM = list(cmodels.TALK_TYPE)
 TALK_TYPE_FORM.insert(0, ("", "----------------"))
 
 class P3SubmissionForm(P3TalkFormMixin, cforms.SubmissionForm):
-    first_time = forms.BooleanField(
-        label=_('I\'m a first-time speaker'),
-        help_text=_('We would love to have more first time speakers at the conference. This setting will be visible for the Program WG to use in their talk selection.'),
-        required=False,
-    )
+    #first_time = forms.BooleanField(
+    #    label=_('I\'m a first-time speaker'),
+    #    help_text=_('This setting will be visible for the Program WG to use in their talk selection. The WG may contact you to ask you to participate in a first time speaker training session.'),
+    #    required=False,
+    #)
     type = forms.TypedChoiceField(
         label=_('Submission type'),
         help_text='Choose between a standard talk, an in-depth training, a poster session or an help desk session',
@@ -104,8 +104,8 @@ class P3SubmissionForm(P3TalkFormMixin, cforms.SubmissionForm):
 
     abstract_extra = forms.CharField(
         max_length=500,
-        label=_('Instructions for attendees of trainings'),
-        help_text=_('<p>Please enter instructions for training attendees, e.g. things to prepare or bring, how to set up the notebook, etc.</p>'),
+        label=_('Additional information for talk reviewers'),
+        help_text=_('<p>Please add anything you may find useful for the review of your talk, e.g. references of where you have held talks, blogs, YouTube channels, books you have written, etc. This information will only be shown for talk review purposes.</p>'),
         widget=cforms.MarkEditWidget,
         required=False)
 

--- a/p3/templates/conference/paper_submission.html
+++ b/p3/templates/conference/paper_submission.html
@@ -33,7 +33,7 @@
                 {{ form.bio|form_field }}
             </fieldset>
             <fieldset>
-                {{ form.first_time|form_field }}
+                <!--{{ form.first_time|form_field }}-->
                 {{ form.personal_agreement|form_field }}
           </fieldset>
         </div><!-- /grid -->


### PR DESCRIPTION
Disable first time speaker checkbox.

Change abstract_extra to be intended for comments to talk reviewers.

Display sorted tag categories.
