### PR TITLE
Make ticket assignments more robust

### DIFF
--- a/assopy/utils.py
+++ b/assopy/utils.py
@@ -1,8 +1,41 @@
 # -*- coding: UTF-8 -*-
 from django.conf import settings as dsettings
+from django.contrib import auth
 from django.core.mail import send_mail as real_send_mail
 
 from assopy import settings
+
+def get_user_account_from_email(email, default='raise'):
+
+    """ Return the user record for the user with the given email
+        address.
+
+        Only active user records are taken into account.
+
+        Note: The system expects the email addresses to be unique
+        among active user records. If there are multiple active user
+        records with the same email address, a MultipleObjectsReturned
+        exception is raised.
+
+        If the user record does not exist, a DoesNotExist exception is
+        raised if default is set to 'raise' (default). Otherwise,
+        default is returned.
+
+    """
+    email = email.strip()
+    try:
+        return auth.models.User.objects.get(email__iexact=email,
+                                            is_active=True)
+    except auth.models.User.DoesNotExist:
+        # User does not exist
+        if default == 'raise':
+            raise
+        else:
+            return default
+    except auth.models.User.MultipleObjectsReturned:
+        # The system expects to only have one user record per email,
+        # so let's reraise the error to have it fixed in the database.
+        raise
 
 def send_email(force=False, *args, **kwargs):
     if force is False and not settings.SEND_EMAIL_TO:

--- a/assopy/views.py
+++ b/assopy/views.py
@@ -16,6 +16,7 @@ from assopy import forms as aforms
 from assopy import janrain
 from assopy import models
 from assopy import settings
+from assopy import utils as autils
 if settings.GENRO_BACKEND:
     from assopy.clients import genro
 from email_template import utils
@@ -206,7 +207,7 @@ def otc_code(request, token):
 
 def _linkProfileToEmail(email, profile):
     try:
-        current = auth.models.User.objects.get(email__iexact=email)
+        current = autils.get_user_account_from_email(email)
     except auth.models.User.DoesNotExist:
         current = auth.models.User.objects.create_user(janrain.suggest_username(profile), email)
         try:
@@ -309,10 +310,7 @@ def janrain_incomplete_profile(request):
                 'profile': p,
             }
             token = models.Token.objects.create(ctype='j', payload=json.dumps(payload))
-            try:
-                current = auth.models.User.objects.get(email=email)
-            except auth.models.User.DoesNotExist:
-                current = None
+            current = autils.get_user_account_from_email(email, default=None)
             utils.email(
                 'janrain-incomplete',
                 ctx={

--- a/p3/admin.py
+++ b/p3/admin.py
@@ -12,6 +12,7 @@ from django.contrib.auth.models import User
 from assopy import admin as aadmin
 from assopy import models as amodels
 from assopy import stats as astats
+from assopy import utils as autils
 from conference import admin as cadmin
 from conference import models as cmodels
 from conference import forms as cforms
@@ -123,7 +124,7 @@ class TicketConferenceAdmin(cadmin.TicketAdmin):
             assigned_to = o.p3_conference.assigned_to
             if assigned_to:
                 try:
-                    user = User.objects.get(email__iexact=assigned_to)
+                    user = autils.get_user_account_from_email(assigned_to)
                 except User.MultipleObjectsReturned:
                     if user.email == assigned_to:
                         # Use the buyer user account

--- a/p3/dataaccess.py
+++ b/p3/dataaccess.py
@@ -3,6 +3,7 @@ from conference import cachef
 from conference import dataaccess as cdata
 from conference import models as cmodels
 from assopy import models as amodels
+from assopy import utils as autils
 from p3 import models
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
@@ -168,7 +169,7 @@ def _i_all_user_tickets(sender, **kw):
         params = [ (o.ticket.user_id, conference) ]
         if o.assigned_to:
             try:
-                uid = User.objects.get(email__iexact=o.assigned_to).id
+                uid = autils.get_user_account_from_email(o.assigned_to).id
             except User.DoesNotExist:
                 pass
             else:

--- a/p3/models.py
+++ b/p3/models.py
@@ -10,6 +10,7 @@ from django.db import models
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.utils.translation import ugettext as _
+from assopy import utils as autils
 
 from conference.models import Ticket, ConferenceTaggedItem, AttendeeProfile, \
     TalkSpeaker, Speaker
@@ -102,9 +103,12 @@ class TicketConference(models.Model):
 
     def profile(self):
         if self.assigned_to:
-            return AttendeeProfile.objects.get(user__email=self.assigned_to)
+            # Ticket assigned to someone else
+            user = autils.get_user_account_from_email(self.assigned_to)
         else:
-            return AttendeeProfile.objects.get(user=self.ticket.user)
+            # Ticket assigned to the buyer
+            user = self.ticket.user
+        return AttendeeProfile.objects.get(user=user)
 
 def _ticket_sim_upload_to(instance, filename):
     subdir = 'p3/personal_documents'

--- a/p3/templates/p3/fragments/render_ticket.html
+++ b/p3/templates/p3/fragments/render_ticket.html
@@ -62,9 +62,9 @@
             {% else %}
             <div class="ticket-commands">
                 <p>
-                    <a href="#" class="edit-button" rel="div[data-ticket={{ ticket.id }}] .overlay">{% trans 'This ticket is for me' %}</a>
+                    <a href="#" class="edit-button" rel="div[data-ticket={{ ticket.id }}] .overlay">{% trans 'Edit this ticket' %}</a>
                     {% if user == ticket.user %}
-                        <br /><a href="#" class="assign-button">{% trans "This ticket is for someone else" %}</a>
+                        <br /><a href="#" class="assign-button">{% trans "Assign ticket to someone else" %}</a>
                     {% endif %}
                     {% orderitem_can_be_refunded ticket.orderitem as r %}
                     {% if r %}

--- a/p3/templatetags/p3.py
+++ b/p3/templatetags/p3.py
@@ -395,8 +395,8 @@ def ticket_user(ticket):
     except models.TicketConference.DoesNotExist:
         p3c = None
     if p3c and p3c.assigned_to:
-        from assopy.models import User
-        return User.objects.get(user__email=p3c.assigned_to)
+        from assopy.utils import get_user_account_from_email
+        return get_user_account_from_email(p3c.assigned_to)
     else:
         return ticket.orderitem.order.user
 


### PR DESCRIPTION
Add new generic helper to get user accounts given an email
address. Use is_active in this helper to be able to "switch" off
duplicate user records.

Use new helper throughout the sytem.

Fix ticket editing dialog to use more accurate hover text buttons.

Make sure that the system always sets .assigned_to, even for
tickets assigned to the buyer when editing and changing assignments.

Make p3.utils.assign_ticket_to_user() helped unconditionally set the
new assigned user. This fixes a bug when reassigning users.
