### PR TITLE
Disable admin entries, now that we have the web-wg as recipient.

### DIFF
--- a/pycon/settings.py
+++ b/pycon/settings.py
@@ -19,11 +19,11 @@ TEMPLATE_DEBUG = DEBUG
 ALLOWED_HOSTS = ['*']
 
 ADMINS = (
-    ('alexsavio', 'alexsavio@gmail.com'),
-    ('oiertwo'  , 'badtrex@gmail.com'),
-    ('fpliger'  , 'fabio.pliger@gmail.com'),
-    ('barrachri', 'barrachri@gmail.com'),
-    ('malemburg', 'mal@europython.eu'),
+#    ('alexsavio', 'alexsavio@gmail.com'),
+#    ('oiertwo'  , 'badtrex@gmail.com'),
+#    ('fpliger'  , 'fabio.pliger@gmail.com'),
+#    ('barrachri', 'barrachri@gmail.com'),
+#    ('malemburg', 'mal@europython.eu'),
     ('web-wg', 'web-wg@europython.eu'),
 )
 


### PR DESCRIPTION
This should reduce the number of emails we get for website
errors.
