### PR TITLE
Get talk voting ready for EP2016

### DIFF
--- a/conference/models.py
+++ b/conference/models.py
@@ -549,14 +549,17 @@ class TalkManager(models.Manager):
 # code in the system uses the codes to checks.
 #
 # TALK_TYPE = (
-#     ('s', 'Talk'),
+#     ('t', 'Talk'),
 #     ('i', 'Interactive'),
-#     ('t', 'Training'),
+#     ('r', 'Training'),
 #     ('p', 'Poster session'),
 #     ('n', 'Panel'),
 #     ('h', 'Help desk'),
 # )
 
+# Talk types combined with duration. Note that the system uses the
+# first character to identify the generic talk type, so these should
+# not be changed from the ones listed above.
 TALK_TYPE = (
     ('t_30', 'Talk (30 mins)'),
     ('t_45', 'Talk (45 mins)'),
@@ -564,8 +567,8 @@ TALK_TYPE = (
     ('i_60', 'Interactive (60 mins)'),
     ('r_180', 'Training (180 mins)'),
     ('p_180', 'Poster session (180 mins)'),
-    ('p_60', 'Panel (60 mins)'),
-    ('p_90', 'Panel (90 mins)'),
+    ('n_60', 'Panel (60 mins)'),
+    ('n_90', 'Panel (90 mins)'),
     ('h_180', 'Help desk (180 mins)'),
 )
 
@@ -577,8 +580,8 @@ TALK_DURATION = {
     'i_60': 60,
     'r_180': 180,
     'p_180': 180,
-    'p_60': 60,
-    'p_90': 90,
+    'n_60': 60,
+    'n_90': 90,
     'h_180': 180,
 }
 

--- a/conference/settings.py
+++ b/conference/settings.py
@@ -140,11 +140,13 @@ TALK_SUBMISSION_LANGUAGES = getattr(
     'CONFERENCE_TALK_SUBMISSION_LANGUAGES',
     settings.LANGUAGES) 
 
+# Voting talk types (only the first letter of TALK_TYPE)
 DEFAULT_VOTING_TALK_TYPES = (
-    ('all', 'All'),
-    ('s', 'Talks'),
-    ('t', 'Trainings'),
-    ('p', 'Poster'),
+    ('t', 'Talks'),
+    ('r', 'Trainings'),
+    #('p', 'Poster'),
+    #('n', 'Panel'),
+    #('h', 'Help desk'),
 )
 
 # List of emails to send talk submission email notifications to

--- a/p3/templates/conference/ajax/voting.html
+++ b/p3/templates/conference/ajax/voting.html
@@ -29,7 +29,7 @@
             <div class="meta">
                 {{ t.type|field_label:"Talk.type" }} for {{ t.level|field_label:"Talk.level" }}
                 {% if t.teaser_video %}&emsp;<span class="video" title="{% trans "Teaser video available" %}"><i class="fa fa-youtube-play"></i>&nbsp;Video</span>{% endif %}
-                {% if t.language == "en" %}&emsp;<span class="international"><i class="fa fa-globe"></i>&nbsp;<abbr>ENG</abbr></span>{% endif %}
+                &emsp;<span class="international"><i class="fa fa-globe"></i>&nbsp;<abbr>{{ t.language|upper }}</abbr></span>
             </div>
             {% endwith %}
             <form action="{% url "conference-voting" %}" method="post">{% csrf_token %}

--- a/p3/templates/conference/voting.html
+++ b/p3/templates/conference/voting.html
@@ -31,9 +31,7 @@
 
                     {{ form.abstracts|form_field:"autosubmit" }}
                     {{ form.talk_type|form_field:"autosubmit" }}
-<!--
                     {{ form.language|form_field:"autosubmit" }}
--->
                     {{ form.order|form_field:"autosubmit" }}
                     {{ form.tags|form_field:"autosubmit" }}
                 </fieldset>
@@ -77,11 +75,10 @@
             <h4>{% trans "How to vote:" %}</h4>
             <ul>
                 <li>{% trans "Click on the stars to cast a vote; half-points are allowed." %}</li>
-                <li>{% trans "Click on the red sign on the left of the stars to remove a vote, if you want to think about it more." %}</li>
+                <li>{% trans "Click on the red sign on the left of the stars to remove a vote, if you want to think about it some more." %}</li>
 
                 <li>{% trans "Use the filters at the top to help you go through the talks." %}</li>
                 <li>{% trans "Sort by vote to help you review all your votes." %}</li>
-
     <!--
                 <li>{% trans "Click on the talk name to go to the (linkable) talk page." %}</li>
                 <li>{% trans "Click on the speaker name to see the (linkable) speaker page, with full bio and other infos." %}</li>


### PR DESCRIPTION
Fix the talk type char for panels to 'n'.

Fix the documented talk type char for talks to 't' and trainings
to 'r'.

Disable all talk voting types except talks and trainings.

Refactor the talk voting form code a bit and use better label
names.

Add 'random' sorting order and make this the default.

Use settings variables rather than hard coded labels in the code.

Enable language output for all talks, not just English ones.

Reenable language filter in talk voting form.
