### PR TITLE
Add sub title to talk voting page.

### DIFF
--- a/p3/static/p6/stylesheets/all.css
+++ b/p3/static/p6/stylesheets/all.css
@@ -184,6 +184,10 @@ small, .meta, #talk-voting .talk-speakers, .person-card .see-more, .ticket-foote
 
 ul, ol { margin: 0 0 0.75em -30px; padding: 0 0 0 30px; }
 
+.subtitle { font-style: italic; font-size: 85%; }
+
+.talk-voting-id { font-size: 50%; }
+
 /*
 li ul,
 li ol {

--- a/p3/templates/conference/ajax/voting.html
+++ b/p3/templates/conference/ajax/voting.html
@@ -19,13 +19,16 @@
                 {% endfor %}
             </div>
             <h3 id="t{{ t.id }}">
-                <a href="#ord{{ row.ordinal }}" id="ord{{ row.ordinal }}">{{ row.ordinal }}</a>&emsp;
                 {% if voting_allowed or special_user %}
                     <a href="{% url "conference-talk" slug=t.slug %}">{{ t.title }}</a>
                 {% else %}
                     {{ t.title }}
                 {% endif %}
+		&nbsp;<a href="#ord{{ row.ordinal }}" id="ord{{ row.ordinal }}" class="talk-voting-id">#{{ row.ordinal }}</a>
             </h3>
+	    {% if t.sub_title %}
+	        <p class="subtitle">{{ t.sub_title }}</p>
+            {% endif %}
             <div class="meta">
                 {{ t.type|field_label:"Talk.type" }} for {{ t.level|field_label:"Talk.level" }}
                 {% if t.teaser_video %}&emsp;<span class="video" title="{% trans "Teaser video available" %}"><i class="fa fa-youtube-play"></i>&nbsp;Video</span>{% endif %}

--- a/p3/templates/conference/talk.xml
+++ b/p3/templates/conference/talk.xml
@@ -9,6 +9,7 @@
     <type>{{ t.type }}</type>
     <public_url>{% url "conference-talk" t.slug as x %}{{ x|full_url }}</public_url>
     <title>{{ t.title }}</title>
+    <subtitle>{{ t.sub_title }}</subtitle>
     <language>{{ t.language }}</language>
     <duration>{{ t.duration }}</duration>
     {% if t.slides %}<slides url="{{ t.slides }}" />{% endif %}


### PR DESCRIPTION
Fix formatting to show the talk submission id small at the
end of the title, instead of large in front.
