### PR TITLE
Fix name abbreviations to better work.

### DIFF
--- a/conference/templatetags/conference.py
+++ b/conference/templatetags/conference.py
@@ -1166,15 +1166,27 @@ def render_fb_like(context, href=None, ref="", show_faces="true", width="100%", 
 
 @register.filter
 def name_abbrv(name):
-    whitelist = set(('de', 'di', 'van', 'mc', 'mac', 'le', 'cotta'))
+    whitelist = set(('de', 'di', 'der',
+                     'van',
+                     'mc', 'mac',
+                     'le',
+                     'cotta',
+                     ))
 
-    splitted = name.split(' ')
-    if len(splitted) == 1:
+    parts = name.split()
+    if len(parts) == 1:
         return name
 
-    last_name = splitted[-1]
-    if splitted[-2].lower() in whitelist:
-        last_name = splitted[-2] + ' ' + last_name
+    parts.reverse()
+    last_name = ''
+    for part in parts:
+        if not last_name:
+            last_name = part
+            continue
+        if part.lower() in whitelist:
+            last_name = part + ' ' + last_name
+        else:
+            break
 
     return '%s. %s' % (name[0], last_name)
 

--- a/p3/utils.py
+++ b/p3/utils.py
@@ -26,7 +26,7 @@ def group_required(*group_names):
             return False
         if user.is_superuser:
             return True
-        return bool(user.groups.filter(name__in=group_names)):
+        return bool(user.groups.filter(name__in=group_names))
     return user_passes_test(group_membership_check)
 
 ### Helpers


### PR DESCRIPTION
Whitelisted terms are now recognized in multiple forms, e.g.
Anthon van der Neut will show up as "A. van der Neut".

Also fixed a typo in p3/utils.py: stray colon.
