### PR TITLE
Add new talk status to dataaccess structure.

### DIFF
--- a/conference/dataaccess.py
+++ b/conference/dataaccess.py
@@ -630,6 +630,7 @@ def profile_data(uid, preload=None):
         'by_conf': {'all': []},
         'accepted': {'all': []},
         'proposed': {'all': []},
+        'canceled': {'all': []},
     }
     for t in talks:
         tid = t['talk']


### PR DESCRIPTION
Fixes traceback caused by PR #368. See #365.

Note: The implementation still is not complete as there are several
other places in the code that assume just "accepted" and "proposed"
as status.
