### PR TITLE
Reenable all talk types, now that the Hottopic CFP is over.

### DIFF
--- a/p3/forms.py
+++ b/p3/forms.py
@@ -41,21 +41,21 @@ class P3TalkFormMixin(object):
 # has not yet submitted another talk; see P3SubmissionAdditionalForm
 # for talk editing and additional talks.
 
-# Hot topic CFP:
-TALK_TYPE_FORM = list((
-    ('t_30', 'Talk (30 mins)'),
-    ('t_45', 'Talk (45 mins)'),
-#    ('t_60', 'Talk (60 mins)'),
-#    ('i_60', 'Interactive (60 mins)'),
-#    ('r_180', 'Training (180 mins)'),
-    ('p_180', 'Poster session (180 mins)'),
-#    ('n_60', 'Panel (60 mins)'),
-#    ('n_90', 'Panel (90 mins)'),
-    ('h_180', 'Help desk (180 mins)'),
-))
+# Hot topic CFP only allows a subset of available talk types:
+#TALK_TYPE_FORM = list((
+#    ('t_30', 'Talk (30 mins)'),
+#    ('t_45', 'Talk (45 mins)'),
+##    ('t_60', 'Talk (60 mins)'),
+##    ('i_60', 'Interactive (60 mins)'),
+##    ('r_180', 'Training (180 mins)'),
+#    ('p_180', 'Poster session (180 mins)'),
+##    ('n_60', 'Panel (60 mins)'),
+##    ('n_90', 'Panel (90 mins)'),
+#    ('h_180', 'Help desk (180 mins)'),
+#))
 
 # Normal CFP:
-#TALK_TYPE_FORM = list(cmodels.TALK_TYPE)
+TALK_TYPE_FORM = list(cmodels.TALK_TYPE)
 
 # Add a non-valid default choice for the talk type to force the user
 # to select one

--- a/pycon/settings.py
+++ b/pycon/settings.py
@@ -317,7 +317,7 @@ INSTALLED_APPS = (
     'cms_utils',
 
     'raven.contrib.django.raven_compat',
-    'django_extensions',
+    #'django_extensions',
 )
 
 # Google ReCaptcha settings


### PR DESCRIPTION
Remove unused django_extensions.
