### PR TITLE
Fix/591/store full invoice information

### DIFF
--- a/assopy/migrations/0003_add_issuer_and_full_html_copy_to_invoice.py
+++ b/assopy/migrations/0003_add_issuer_and_full_html_copy_to_invoice.py
@@ -19,18 +19,8 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='invoice',
-            name='items_copy',
+            name='invoice_copy_full_html',
             field=models.TextField(default=''),
             preserve_default=False,
-        ),
-        migrations.AlterField(
-            model_name='order',
-            name='cf_code',
-            field=models.CharField(max_length=16, verbose_name='Fiscal Code', blank=True),
-        ),
-        migrations.AlterField(
-            model_name='user',
-            name='cf_code',
-            field=models.CharField(help_text='Needed only for Italian customers', max_length=16, verbose_name='Fiscal Code', blank=True),
         ),
     ]

--- a/assopy/migrations/0003_add_issuer_and_items_copy_to_invoice.py
+++ b/assopy/migrations/0003_add_issuer_and_items_copy_to_invoice.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assopy', '0002_order_stripe_charge_id'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='invoice',
+            name='issuer',
+            field=models.TextField(default=''),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='invoice',
+            name='items_copy',
+            field=models.TextField(default=''),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='order',
+            name='cf_code',
+            field=models.CharField(max_length=16, verbose_name='Fiscal Code', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='user',
+            name='cf_code',
+            field=models.CharField(help_text='Needed only for Italian customers', max_length=16, verbose_name='Fiscal Code', blank=True),
+        ),
+    ]

--- a/assopy/models.py
+++ b/assopy/models.py
@@ -24,7 +24,7 @@ from assopy import settings
 from assopy.utils import send_email
 from common import django_urls
 from conference.models import Ticket
-from conference.invoicing import ISSUER_BY_YEAR
+from conference.invoicing import ISSUER_BY_YEAR, render_invoice_as_html
 from email_template import utils
 
 if settings.GENRO_BACKEND:
@@ -873,7 +873,7 @@ class InvoiceManager(models.Manager):
                         'issuer': ISSUER_BY_YEAR[emit_date.year],
                     }
                 )
-                # TODO: Dump what's on the invoice as well
+
                 if not created:
                     if not payment_date or i.payment_date:
                         raise RuntimeError('Payment date mismatch')
@@ -881,8 +881,9 @@ class InvoiceManager(models.Manager):
                         i.payment_date = payment_date
                         i.emit_date = emit_date
                         i.code = vat_item['code']
-                        i.save()
 
+                i.invoice_copy_full_html = render_invoice_as_html(i)
+                i.save()
                 invoices.append(i)
             return invoices
 
@@ -896,7 +897,7 @@ class Invoice(models.Model):
     price = models.DecimalField(max_digits=6, decimal_places=2)
 
     issuer = models.TextField()
-    items_copy = models.TextField()
+    invoice_copy_full_html = models.TextField()
 
     # indica il tipo di regime iva associato alla fattura perche vengono
     # generate più fatture per ogni ordine contente orderitems con diverso

--- a/assopy/models.py
+++ b/assopy/models.py
@@ -180,9 +180,12 @@ def _fs_upload_to(subdir, attr=None):
 # query guardando i Conference.Ticket
 ticket_for_user = dispatch.Signal(providing_args=['tickets'])
 
+
 class User(models.Model):
     """
-    aka. AssopyUser
+    aka. AssopyUser; There are multiple models called 'User', this one, and the
+    bultin django one from django.contrib.auth.models; This model is often
+    referred to in other places as 'AssopyUser' for clarity.
     """
     user = models.OneToOneField("auth.User", related_name='assopy_user')
     token = models.CharField(max_length=36, unique=True, null=True, blank=True)

--- a/assopy/models.py
+++ b/assopy/models.py
@@ -1,23 +1,4 @@
 # -*- coding: UTF-8 -*-
-from assopy import janrain
-from assopy import settings
-from common import django_urls
-
-if settings.GENRO_BACKEND:
-    from assopy.clients import genro, vies
-from assopy.utils import check_database_schema, send_email
-from conference.models import Ticket
-from email_template import utils
-
-from django import dispatch
-from django.conf import settings as dsettings
-from django.contrib import auth
-from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
-from django.db import models
-from django.db.models.query import QuerySet
-from django.utils.translation import ugettext_lazy as _
-from django.utils.timezone import now
 
 import re
 import os
@@ -27,6 +8,27 @@ from uuid import uuid4
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from collections import defaultdict
+
+from django import dispatch
+from django.conf import settings as dsettings
+from django.contrib import auth
+from django.core.exceptions import ValidationError
+from django.core.urlresolvers import reverse
+from django.db import models
+from django.db.models.query import QuerySet
+from django.utils.timezone import now
+from django.utils.translation import ugettext_lazy as _
+
+from assopy import janrain
+from assopy import settings
+from assopy.utils import send_email
+from common import django_urls
+from conference.models import Ticket
+from conference.invoicing import ISSUER_BY_YEAR
+from email_template import utils
+
+if settings.GENRO_BACKEND:
+    from assopy.clients import genro, vies
 
 log = logging.getLogger('assopy.models')
 
@@ -865,11 +867,13 @@ class InvoiceManager(models.Manager):
                     vat=vat_item['vat'],
                     price=vat_item['price'],
                     defaults={
-                        'code' : vat_item['code'],
-                        'payment_date' : payment_date,
-                        'emit_date' : emit_date,
+                        'code': vat_item['code'],
+                        'payment_date': payment_date,
+                        'emit_date': emit_date,
+                        'issuer': ISSUER_BY_YEAR[emit_date.year],
                     }
                 )
+                # TODO: Dump what's on the invoice as well
                 if not created:
                     if not payment_date or i.payment_date:
                         raise RuntimeError('Payment date mismatch')
@@ -890,6 +894,9 @@ class Invoice(models.Model):
     emit_date = models.DateField()
     payment_date = models.DateField(null=True, blank=True)
     price = models.DecimalField(max_digits=6, decimal_places=2)
+
+    issuer = models.TextField()
+    items_copy = models.TextField()
 
     # indica il tipo di regime iva associato alla fattura perche vengono
     # generate più fatture per ogni ordine contente orderitems con diverso

--- a/assopy/views.py
+++ b/assopy/views.py
@@ -421,6 +421,8 @@ def invoice(request, order_code, code, mode='html'):
     if mode == 'html':
         order = invoice.order
         address = '%s, %s' % (order.address, unicode(order.country))
+        # TODO: why, instead of passing invoice objects, it explicitly passes
+        # every attribute?
         ctx = {
             'document': ('Fattura N.', 'Invoice N.'),
             'title': unicode(invoice),
@@ -442,6 +444,7 @@ def invoice(request, order_code, code, mode='html'):
             },
             'vat': invoice.vat,
             'real': settings.IS_REAL_INVOICE(invoice.code),
+            "issuer": invoice.issuer,
         }
         return render_to_response('assopy/invoice.html', ctx, RequestContext(request))
     else:

--- a/assopy/views.py
+++ b/assopy/views.py
@@ -419,34 +419,8 @@ def invoice(request, order_code, code, mode='html'):
         **userfilter
     )
     if mode == 'html':
-        order = invoice.order
-        address = '%s, %s' % (order.address, unicode(order.country))
-        # TODO: why, instead of passing invoice objects, it explicitly passes
-        # every attribute?
-        ctx = {
-            'document': ('Fattura N.', 'Invoice N.'),
-            'title': unicode(invoice),
-            'code': invoice.code,
-            'emit_date': invoice.emit_date,
-            'order': {
-                'card_name': order.card_name,
-                'address': address,
-                'billing_notes': order.billing_notes,
-                'cf_code': order.cf_code,
-                'vat_number': order.vat_number,
-            },
-            'items': invoice.invoice_items(),
-            'note': invoice.note,
-            'price': {
-                'net': invoice.net_price(),
-                'vat': invoice.vat_value(),
-                'total': invoice.price,
-            },
-            'vat': invoice.vat,
-            'real': settings.IS_REAL_INVOICE(invoice.code),
-            "issuer": invoice.issuer,
-        }
-        return render_to_response('assopy/invoice.html', ctx, RequestContext(request))
+        return http.HttpResponse(invoice.invoice_copy_full_html)
+
     else:
         if settings.GENRO_BACKEND:
             assopy_id = invoice.assopy_id

--- a/conference/invoicing.py
+++ b/conference/invoicing.py
@@ -1,0 +1,7 @@
+# coding: utf-8
+
+ISSUER_BY_YEAR = {
+    2016: "Bilbao FIXME",
+    2017: "Rimini FIXME",
+    2018: "TBA FIXME",
+}

--- a/conference/invoicing.py
+++ b/conference/invoicing.py
@@ -1,7 +1,51 @@
 # coding: utf-8
 
+from __future__ import unicode_literals, absolute_import
+
+from django.template.loader import render_to_string
+
+from assopy.settings import IS_REAL_INVOICE
+
+
 ISSUER_BY_YEAR = {
     2016: "Bilbao FIXME",
     2017: "Rimini FIXME",
-    2018: "TBA FIXME",
+    2018: "Edinburgh FIXME",
 }
+
+
+def render_invoice_as_html(invoice):
+
+    # TODO this is copied as-is from assopy/views.py, but can be simplified
+    # TODO: also if there are any images included in the invoice make sure to
+    # base64 them.
+
+    order = invoice.order
+    address = '%s, %s' % (order.address, unicode(order.country))
+    # TODO: why, instead of passing invoice objects, it explicitly passes
+    # every attribute?
+    ctx = {
+        'document': ('Fattura N.', 'Invoice N.'),
+        'title': unicode(invoice),
+        'code': invoice.code,
+        'emit_date': invoice.emit_date,
+        'order': {
+            'card_name': order.card_name,
+            'address': address,
+            'billing_notes': order.billing_notes,
+            'cf_code': order.cf_code,
+            'vat_number': order.vat_number,
+        },
+        'items': invoice.invoice_items(),
+        'note': invoice.note,
+        'price': {
+            'net': invoice.net_price(),
+            'vat': invoice.vat_value(),
+            'total': invoice.price,
+        },
+        'vat': invoice.vat,
+        'real': IS_REAL_INVOICE(invoice.code),
+        "issuer": invoice.issuer,
+    }
+
+    return render_to_string('assopy/invoice.html', ctx)

--- a/conference/settings.py
+++ b/conference/settings.py
@@ -31,7 +31,9 @@ FORMS.update(getattr(settings, 'CONFERENCE_FORMS', {}))
 import os
 # FIXME: This part is hardcoded, why ?
 #MAX_TICKETS =  os.environ.get("MAX_TICKETS")
-MAX_TICKETS = 350
+# (artcz) Setting to 6 because that was/is the value in the javascript for the
+# cart.
+MAX_TICKETS = 6
 
 # URL that will receive a user who tries to access the paper submission when the CFP is closed
 # None if a 404 is returned

--- a/p3/templates/assopy/invoice.html
+++ b/p3/templates/assopy/invoice.html
@@ -16,13 +16,7 @@
         <!-- <img src="{{ STATIC_URL }}" /> -->
     </div>
     <div class="companyinfo">
-Python Italia APS<br />
-Via Mugellese, 1/A<br />
-50013 Campi Bisenzio (FI)<br />
-Italy<br />
-VAT-ID: IT05753460483<br />
-Codice Fiscale: 94144670489<br />
-Contact Email: info@python.it<br />
+        {{ issuer }}
     </div>
     <div class="clear"></div>
 {% endblock %}

--- a/p3/templates/assopy/profile.html
+++ b/p3/templates/assopy/profile.html
@@ -120,7 +120,7 @@
                     {% endif %}
                 {% endwith %}
 
-                {% with request.user.assopy_user.orders as orders %}
+                {% with request.user.assopy_user.get_orders as orders %}
                 <div class="profile-user-data tickets">
                     <h4>{% trans "Your orders" %}</h4>
                     <table class="table">
@@ -132,20 +132,20 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {% for o in orders.all %}
+                            {% for order in orders %}
                             <tr>
-                                <td>{{ o.code }}</td>
-                                <td>{{ o.created|date:"d M Y" }}</td>
+                                <td>{{ order.code }}</td>
+                                <td>{{ order.created|date:"d M Y" }}</td>
                                 <td>
-                                    {% with o.invoices.all as invoices %}
+                                    {% with order.invoices.all as invoices %}
                                     {% if not invoices %}
                                     {% trans "N/A" %}
                                     {% else %}
-                                        {% for i in invoices %}
-                                            {% if i.assopy_id %}
-                                                <a href="{% url 'genro-legacy-invoice' assopy_id=i.assopy_id %}">{{ i.code }}</a>
+                                        {% for invoice in invoices %}
+                                            {% if invoice.assopy_id %}
+                                                <a href="{% url 'genro-legacy-invoice' assopy_id=invoice.assopy_id %}">{{ invoice.code }}</a>
                                             {% else %}
-                                                <a href="{% url 'assopy-invoice-html' order_code=o.code code=i.code %}">{{ i.code }}</a>
+                                                <a href="{% url 'assopy-invoice-html' order_code=order.code code=invoice.code %}">{{ invoice.code }}</a>
                                                 {% comment %}
                                                 {% for cn in i.credit_notes.all %}
                                                     (<a href="{% url 'assopy-invoice-html' assopy_id=cn.assopy_id %}">{{ cn.code }}</a> refund)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+freezegun
 factory_boy
 selenium
 mock

--- a/tests/common_tools.py
+++ b/tests/common_tools.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals, absolute_import
 
+from wsgiref.simple_server import make_server
+
 from cms.api import create_page
 
 from django.conf import settings
@@ -29,3 +31,23 @@ def create_homepage_in_cms():
     create_page(title='HOME', template='django_cms/p5_homepage.html',
                 language='en', reverse_id='home', published=True,
                 publication_date=timezone.now())
+
+
+def serve(content, host='0.0.0.0', port=9876):
+    """
+    Useful when doing stuff with pdb -- can serve aribtrary string with http.
+
+    use case: looking at response.content in tests.
+
+    usage: 1) serve(response.content),
+           2) go to http://localhost:9876/
+           3) PROFIT
+    """
+
+    def render(env, sr):
+        sr(b'200 OK', [(b'Content-Type', b'text/html'), ])
+        return [content]
+
+    srv = make_server(host, port, render)
+    print "Go to http://{}:{}".format(host, port)
+    srv.serve_forever()

--- a/tests/common_tools.py
+++ b/tests/common_tools.py
@@ -51,3 +51,17 @@ def serve(content, host='0.0.0.0', port=9876):
     srv = make_server(host, port, render)
     print "Go to http://{}:{}".format(host, port)
     srv.serve_forever()
+
+
+def sequence_equals(sequence1, sequence2):
+    """
+    Inspired by django's self.assertSequenceEquals
+
+    Useful for comparing lists with querysets and similar situations where
+    simple == fails because of different type.
+    """
+    assert len(sequence1) == len(sequence2), (len(sequence1), len(sequence2))
+    for item_from_s1, item_from_s2 in zip(sequence1, sequence2):
+        assert item_from_s1 == item_from_s2, (item_from_s1, item_from_s2)
+
+    return True

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -284,6 +284,8 @@ def test_invoices_from_buying_tickets(client):
     assert invoice_vat_10.price == gross_price_vat_10
     assert invoice_vat_10.net_price() == net_price_vat_10
     assert invoice_vat_10.vat_value() == vat_value_vat_10
+    assert invoice_vat_10.invoice_copy_full_html.startswith('<!DOCTYPE')
+    assert len(invoice_vat_10.invoice_copy_full_html) > 1000  # large html blob
 
     # do the same for vat 20%
     gross_price_vat_20 = social_event_price * social_event_amount
@@ -293,6 +295,8 @@ def test_invoices_from_buying_tickets(client):
     assert invoice_vat_20.price == gross_price_vat_20
     assert invoice_vat_20.net_price() == net_price_vat_20
     assert invoice_vat_20.vat_value() == vat_value_vat_20
+    assert invoice_vat_20.invoice_copy_full_html.startswith('<!DOCTYPE')
+    assert len(invoice_vat_20.invoice_copy_full_html) > 1000  # large html blob
 
     # each OrderItem should have a corresponding Ticket
     assert Ticket.objects.all().count() ==\
@@ -351,6 +355,7 @@ def test_if_invoice_stores_information_about_the_seller(client):
         assert invoice.code == "I/16.0001"
         assert invoice.emit_date == date(2016, 1, 1)
         assert invoice.issuer == "Bilbao FIXME"
+        assert invoice.invoice_copy_full_html.startswith('<!DOCTYPE')
 
         response = client.get(invoice_url(invoice))
         assert "Bilbao FIXME" in response.content.decode('utf-8')
@@ -360,6 +365,7 @@ def test_if_invoice_stores_information_about_the_seller(client):
         assert invoice.code == "I/17.0001"
         assert invoice.emit_date == date(2017, 1, 1)
         assert invoice.issuer == "Rimini FIXME"
+        assert invoice.invoice_copy_full_html.startswith('<!DOCTYPE')
 
         response = client.get(invoice_url(invoice))
         assert "Rimini FIXME" in response.content.decode('utf-8')
@@ -373,7 +379,8 @@ def test_if_invoice_stores_information_about_the_seller(client):
         invoice = create_order_and_invoice()
         assert invoice.code == "I/18.0001"
         assert invoice.emit_date == date(2018, 1, 1)
-        assert invoice.issuer == "TBA FIXME"
+        assert invoice.issuer == "Edinburgh FIXME"
+        assert invoice.invoice_copy_full_html.startswith('<!DOCTYPE')
 
         response = client.get(invoice_url(invoice))
-        assert "TBA FIXME" in response.content.decode('utf-8')
+        assert "Edinburgh FIXME" in response.content.decode('utf-8')

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -23,7 +23,7 @@ from tests.common_tools import template_used, sequence_equals, serve  # NOQA
 
 
 @mark.django_db
-def test_592_dont_display_invoices_for_yeras_before_2018(client):
+def test_592_dont_display_invoices_for_years_before_2018(client):
     """
     https://github.com/EuroPython/epcon/issues/592
 

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -1,0 +1,89 @@
+# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+
+from datetime import date
+from decimal import Decimal
+
+from pytest import mark
+
+from django.core.urlresolvers import reverse
+
+from django_factory_boy import auth as auth_factories
+
+# TODO: clean up this import path
+from assopy.models import Invoice, Order, Vat
+from assopy.tests.factories.user import UserFactory as AssopyUserFactory
+from conference.models import AttendeeProfile
+
+from tests.common_tools import template_used
+
+
+@mark.django_db
+def test_591_dont_display_invoices_for_yeras_before_2018(client):
+    """
+    https://github.com/EuroPython/epcon/issues/592
+
+    Temporary(?) test for #592, until #591 is fixed.
+    """
+
+    # default password is 'password123' per django_factory_boy
+    user = auth_factories.UserFactory(email='joedoe@example.com',
+                                      is_active=True)
+
+    # both are required to access user profile page.
+    assopy_user = AssopyUserFactory(user=user)
+    AttendeeProfile.objects.create(user=user, slug='foobar')
+
+    client.login(email='joedoe@example.com', password='password123')
+
+    # create some random Vat instance to the invoice creation works
+    vat_10 = Vat.objects.create(value=10)
+
+    # invoice_code must be validated via ASSOPY_IS_REAL_INVOICE
+    invoice_code_2017, order_code_2017 = 'I2017', 'O2017'
+    invoice_code_2018, order_code_2018 = 'I2018', 'O2018'
+
+    order2017 = Order(user=assopy_user, code=order_code_2017)
+    order2017.save()
+    order2017.created = date(2017, 12, 31)
+    order2017.save()
+
+    order2018 = Order(user=assopy_user, code=order_code_2018)
+    order2018.save()
+    order2018.created = date(2018, 1, 1)
+    order2018.save()
+
+    Invoice.objects.create(
+        code=invoice_code_2017,
+        order=order2017,
+        emit_date=date(2017, 3, 13),
+        price=Decimal(1337),
+        vat=vat_10,
+    )
+
+    # Doesn't matter when the invoice was issued (invoice.emit_date),
+    # it only matters what's the Order.created date
+    Invoice.objects.create(
+        code=invoice_code_2018,
+        order=order2018,
+        emit_date=date(2017, 3, 13),
+        price=Decimal(1337),
+        vat=vat_10,
+    )
+
+    user_profile_url = reverse("assopy-profile")
+    response = client.get(user_profile_url)
+
+    assert invoice_code_2017 not in response.content.decode('utf-8')
+    assert order_code_2017 not in response.content.decode('utf-8')
+
+    assert invoice_code_2018 in response.content.decode('utf-8')
+    assert order_code_2018 in response.content.decode('utf-8')
+
+    assert reverse("assopy-invoice-html", kwargs={
+        'code': invoice_code_2018,
+        'order_code': order_code_2018,
+    }) in response.content.decode('utf-8')
+
+    assert template_used(response, 'assopy/profile.html')

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -2,25 +2,28 @@
 
 from __future__ import unicode_literals, absolute_import
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 
 from pytest import mark
 
 from django.core.urlresolvers import reverse
+from django.conf import settings
 
 from django_factory_boy import auth as auth_factories
+from freezegun import freeze_time
 
-# TODO: clean up this import path
-from assopy.models import Invoice, Order, Vat
+from assopy.models import Country, Invoice, Order, Vat, VatFare
 from assopy.tests.factories.user import UserFactory as AssopyUserFactory
-from conference.models import AttendeeProfile
+from conference.models import AttendeeProfile, Fare, Ticket
+from conference import settings as conference_settings
+from email_template.models import Email
 
-from tests.common_tools import template_used
+from tests.common_tools import template_used, sequence_equals, serve  # NOQA
 
 
 @mark.django_db
-def test_591_dont_display_invoices_for_yeras_before_2018(client):
+def test_592_dont_display_invoices_for_yeras_before_2018(client):
     """
     https://github.com/EuroPython/epcon/issues/592
 
@@ -87,3 +90,161 @@ def test_591_dont_display_invoices_for_yeras_before_2018(client):
     }) in response.content.decode('utf-8')
 
     assert template_used(response, 'assopy/profile.html')
+
+
+@mark.django_db
+@freeze_time("2018-01-01")
+def test_invoices_from_buying_tickets(client):
+    """
+    This is an example of a full flow, of creating and buying a new ticket.
+    """
+
+    assert settings.P3_FARES_ENABLED
+
+    # 1. First create a user with complete profile.
+    # default password is 'password123' per django_factory_boy
+    user = auth_factories.UserFactory(email='joedoe@example.com',
+                                      is_active=True)
+
+    # both are required to access user profile page.
+    AssopyUserFactory(user=user)
+    AttendeeProfile.objects.create(user=user, slug='foobar')
+
+    client.login(email='joedoe@example.com', password='password123')
+
+    # 2. Let's start with checking if no tickets are available at first
+    cart_url = reverse('p3-cart')
+    response = client.get(cart_url)
+    assert template_used(response, "p3/cart.html")
+    assert 'Sorry, no tickets are available' in response.content
+
+    # 3. p3/cart.html is using {% fares_available %} assignment tag
+    # lets create some fares.
+    # just setting a single type of ticket, for testing. In reality there are
+    # 27 possible fare types for just the tickets
+    #   (early bird, regular, on desk)
+    # x (standard, stndard light, day pass)
+    # x (student, personal, company)
+
+    # fare_codes = [
+    #     'T' + ticket_type + ticket_variant + group_type
+    #     # E = Early Bird, R = Regular, D = on Desk
+    #     for ticket_type in ['E', 'R', 'D']
+    #     # S = Standard; L = Standard Light (no trainings); D = Day Pass
+    #     for ticket_variant in ['S', 'L', 'D']
+    #     # S = Student; P = Personal; C = Company
+    #     for group_type in ['S', 'P', 'C']
+    # ]
+
+    PRICE_PER_UNIT = Decimal("213.7")
+
+    fare = Fare.objects.create(
+        conference=settings.CONFERENCE_CONFERENCE,
+        name="Testing Regular Standard",
+        description="Testing Regular Standard Description",
+        code='TRSP',  # Ticket Regular Standard Personal
+        price=PRICE_PER_UNIT,
+        start_validity=date.today() - timedelta(days=10),
+        end_validity=date.today() + timedelta(days=10),
+    )
+
+    # fare also needs VAT
+    vat_10 = Vat.objects.create(value=10)
+    VatFare.objects.create(fare=fare, vat=vat_10)
+
+    # 4. If Fare is created we should have one input on the cart.
+    response = client.get(cart_url)
+    assert template_used(response, "p3/cart.html")
+    _response_content = response.content.decode('utf-8')
+    assert 'Sorry, no tickets are available' not in _response_content
+    assert 'Buy tickets (1 of 2)' in _response_content
+
+    # There are plenty of tds but only TRSP should have data-fare set
+    assert 'td class="fare" data-fare="TRSP">' in _response_content
+    assert 'td class="fare" data-fare="TDCP">' not in _response_content
+    assert 'td class="fare" data-fare="">' in _response_content
+
+    # and one input for TRSP where you can specify how many tickets
+    # TODO: maybe it should have a different type than text?
+    assert '<input type="text" size="2" name="TRSP"' in _response_content
+
+    # 5. Try buying some tickets
+    # FIXME: looks like the max_tickets is enforced only with javascript
+    QUANTITY = 20
+    assert QUANTITY > conference_settings.MAX_TICKETS
+    response = client.post(cart_url, {
+        'order_type': 'non-deductible',  # == Personal
+        'TRSP': QUANTITY,
+    }, follow=True)
+    billing_url = reverse('p3-billing')
+    assert response.status_code == 200
+    assert response.request['PATH_INFO'] == billing_url
+    assert billing_url == '/p3/billing/'
+
+    assert 'Buy tickets (2 of 2)' in response.content.decode('utf-8')
+
+    # unless you POST to the billing page the Order is not created
+    assert Order.objects.count() == 0
+
+    Country.objects.create(iso='PL', name='Poland')
+    response = client.post(billing_url, {
+        'card_name': 'Joe Doe',
+        'payment': 'cc',
+        'country': 'PL',
+        'address': 'Random 42',
+        'cf_code': '31447',
+        'code_conduct': True,
+    }, follow=True)
+    assert response.status_code == 200
+    assert response.request['PATH_INFO'] == '/accounts/stripe/checkout/1/'
+
+    order = Order.objects.get()
+    # FIXME: confirming that max_tickets is only enforced in javascript
+    assert order.orderitem_set.all().count() == QUANTITY
+
+    # need to create an email template that's used in the purchasing process
+    Email.objects.create(code='purchase-complete')
+
+    # no invoices
+    assert Invoice.objects.all().count() == 0
+    # static date, because of #592 choosing something in 2018
+    order.confirm_order(date(2018, 1, 1))
+
+    # 20 items but just one invoice
+    assert Invoice.objects.all().count() == 1
+
+    invoice = Invoice.objects.get()
+
+    # only one orderitem_set instance because they are grouped by fare_code
+    expected_invoice_items = [{'count': QUANTITY,
+                               'price': QUANTITY * PRICE_PER_UNIT,
+                               'code': u'TRSP',
+                               'description': u'Testing Regular Standard'}]
+
+    assert sequence_equals(invoice.invoice_items(), expected_invoice_items)
+
+    gross_price = QUANTITY * PRICE_PER_UNIT
+    net_price = gross_price / Decimal('1.1')  # 110% - 100% net and 10% vat
+    vat_value = gross_price - net_price
+
+    assert invoice.price == gross_price
+    assert invoice.net_price() == net_price
+    assert invoice.vat_value() == vat_value
+
+    # each OrderItem should have a corresponding Ticket
+    assert Ticket.objects.all().count() == QUANTITY
+
+    # Check if user profile has the tickets and invoices available
+    profile_url = reverse('assopy-profile')
+    response = client.get(profile_url)
+
+    # order code depends on when this test is run, but invoice code should
+    # default to whatever payment_date is (in this case 2018, 1, 1)
+    # TODO: currently this test is under freezegun, but we may want to remove
+    # it later and replace with APIs that allows to control/specify date for
+    # order and invoice.
+    assert 'O/18.0001' in response.content.decode('utf-8')
+    assert 'I/18.0001' in response.content.decode('utf-8')
+
+    # TODO: add social event tickets/invoices
+    # This should produce another invoice to the same Order(?)


### PR DESCRIPTION
Things left to decide/fix:

* Fill in the details about issuers by year in conference/invoices.py

* ~~Store full html of the invoice once generated.~~

Things to fix in separate PR:

* Store pdf of the invoice

also, depends on merging #594 first, and this branch is based on branch from #594, so the diff is more noisy than it should be.