### PR TITLE
Fix invoice issuers for 2016, 2017 and 2018

### DIFF
--- a/conference/invoicing.py
+++ b/conference/invoicing.py
@@ -37,11 +37,20 @@ Codice Fiscale: 94144670489
 Contact Email: info@python.it
 """.strip()
 
+EPS_18 = """
+EuroPython Society
+c/o Open End AB
+Norra Ågatan 10
+41664  Göteborg
+Sweden
+EU VAT-ID: SE802417770401
+"""
+
 
 ISSUER_BY_YEAR = {
     2016: ACPYSS_16,
     2017: PYTHON_ITALIA_17,
-    2018: "Edinburgh FIXME",
+    2018: EPS_18,
 }
 
 REAL_INVOICE_PREFIX = "I/"

--- a/conference/invoicing.py
+++ b/conference/invoicing.py
@@ -44,6 +44,8 @@ Norra Ågatan 10
 41664  Göteborg
 Sweden
 EU VAT-ID: SE802417770401
+Contact Email: billing@europython.eu
+https://www.europython-society.org
 """
 
 

--- a/conference/invoicing.py
+++ b/conference/invoicing.py
@@ -19,10 +19,28 @@ from django.db import transaction
 
 from assopy.models import Invoice, Order
 
+ACPYSS_16 = """
+Asociación de Ciencias de la Programación Python San Sebastian (ACPySS)
+P° Manuel Lardizabal 1, Oficina 307-20018 Donostia (Spain)
+VAT-ID ESG75119511
+Tel/Phone (+34) 943.01.80.47 | (+34) 688.64.52.32
+Email: info@pyss.org
+""".strip()
+
+PYTHON_ITALIA_17 = """
+Python Italia APS
+Via Mugellese, 1/A
+50013 Campi Bisenzio (FI)
+Italy
+VAT-ID: IT05753460483
+Codice Fiscale: 94144670489
+Contact Email: info@python.it
+""".strip()
+
 
 ISSUER_BY_YEAR = {
-    2016: "Bilbao FIXME",
-    2017: "Rimini FIXME",
+    2016: ACPYSS_16,
+    2017: PYTHON_ITALIA_17,
     2018: "Edinburgh FIXME",
 }
 

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -17,6 +17,7 @@ from assopy.models import Country, Invoice, Order, Vat, VatFare
 from assopy.tests.factories.user import UserFactory as AssopyUserFactory
 from conference.models import AttendeeProfile, Fare, Ticket
 from conference import settings as conference_settings
+from conference.invoicing import ACPYSS_16, PYTHON_ITALIA_17
 from email_template.models import Email
 
 from tests.common_tools import template_used, sequence_equals, serve  # NOQA
@@ -411,21 +412,21 @@ def test_if_invoice_stores_information_about_the_seller(client):
         invoice = create_order_and_invoice()
         assert invoice.code == "I/16.0001"
         assert invoice.emit_date == date(2016, 1, 1)
-        assert invoice.issuer == "Bilbao FIXME"
+        assert invoice.issuer == ACPYSS_16
         assert invoice.invoice_copy_full_html.startswith('<!DOCTYPE')
 
         response = client.get(invoice_url(invoice))
-        assert "Bilbao FIXME" in response.content.decode('utf-8')
+        assert ACPYSS_16 in response.content.decode('utf-8')
 
     with freeze_time("2017-01-01"):
         invoice = create_order_and_invoice()
         assert invoice.code == "I/17.0001"
         assert invoice.emit_date == date(2017, 1, 1)
-        assert invoice.issuer == "Rimini FIXME"
+        assert invoice.issuer == PYTHON_ITALIA_17
         assert invoice.invoice_copy_full_html.startswith('<!DOCTYPE')
 
         response = client.get(invoice_url(invoice))
-        assert "Rimini FIXME" in response.content.decode('utf-8')
+        assert PYTHON_ITALIA_17 in response.content.decode('utf-8')
 
     with freeze_time("2018-01-01"):
         # (2017-11-14) for some reason we need to log in again to see the

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -17,7 +17,7 @@ from assopy.models import Country, Invoice, Order, Vat, VatFare
 from assopy.tests.factories.user import UserFactory as AssopyUserFactory
 from conference.models import AttendeeProfile, Fare, Ticket
 from conference import settings as conference_settings
-from conference.invoicing import ACPYSS_16, PYTHON_ITALIA_17
+from conference.invoicing import ACPYSS_16, PYTHON_ITALIA_17, EPS_18
 from email_template.models import Email
 
 from tests.common_tools import template_used, sequence_equals, serve  # NOQA
@@ -437,8 +437,8 @@ def test_if_invoice_stores_information_about_the_seller(client):
         invoice = create_order_and_invoice()
         assert invoice.code == "I/18.0001"
         assert invoice.emit_date == date(2018, 1, 1)
-        assert invoice.issuer == "Edinburgh FIXME"
+        assert invoice.issuer == EPS_18
         assert invoice.invoice_copy_full_html.startswith('<!DOCTYPE')
 
         response = client.get(invoice_url(invoice))
-        assert "Edinburgh FIXME" in response.content.decode('utf-8')
+        assert EPS_18 in response.content.decode('utf-8')


### PR DESCRIPTION
I've replaced placeholder issuers for 2016, 2017 based on my own invoices (in case we need to reissue copy of some invoice).
~~One missing thing is the issuer for 2018, we should probably add that in this PR too.~~
2018 based on https://www.europython-society.org/about