### PR TITLE
Allow to specify a talk domain

### DIFF
--- a/p3/forms.py
+++ b/p3/forms.py
@@ -93,8 +93,8 @@ class P3SubmissionForm(P3TalkFormMixin, cforms.SubmissionForm):
 
 
     sub_community = forms.ChoiceField(
-        label=_('Sub community'),
-        help_text=_('Select the sub community this talk is intended for, if any.'),
+        label=_('Domain / Track'),
+        help_text=_('Select the domain of the talk, this will help us with the conference scheduling.'),
         choices=models.TALK_SUBCOMMUNITY,
         initial='',
         required=False)

--- a/pycon/settings.py
+++ b/pycon/settings.py
@@ -596,8 +596,16 @@ CONFERENCE_ADMIN_TICKETS_STATS_EMAIL_LOAD_LIBRARY = ['p3', 'conference']
 
 # Conference sub-communities
 CONFERENCE_TALK_SUBCOMMUNITY = (
-    ('', _('All')),
-    ('pydata', _('PyData')),
+    ('business_track', _('Business Track')),
+    ('devops', _('DevOps')),
+    ('django', _('Django Track')),
+    ('education', _('Educational Track')),
+    ('general', _('General Python')),
+    ('hw_iot', _('Hardware/IoT Track')),
+    ('pydata', _('PyData Track')),
+    ('science', _('Science Track')),
+    ('web', _('Web Track')),
+    ('', 'None of the above')
 )
 
 ### Ticket information


### PR DESCRIPTION
How it looks: 

<img width="1060" alt="screen shot 2018-04-08 at 19 04 42" src="https://user-images.githubusercontent.com/667029/38470817-22ca11e0-3b60-11e8-8ed5-e781fe772792.png">

@alanderex I've named it `Domain / Track`, not sure if is the correct working, also can I have a feedback on the help text?

> Select the domain of the talk, this will help us with the conference scheduling

@malemburg shall we rename the field to something else? I've reused the sub communities one :)