### PR TITLE
 Bump abstract char limit to 5000

### DIFF
--- a/conference/forms.py
+++ b/conference/forms.py
@@ -177,7 +177,7 @@ class TalkBaseForm(forms.Form):
         widget=forms.TextInput(attrs={'size': 40}),
         required=False)
     abstract = forms.CharField(
-        max_length=1500,
+        max_length=5000,
         label=_('Abstract (longer version)'),
         help_text=_('<p>Description of the session proposal you are submitting. Be sure to include the goals and any prerequisite required to fully understand it. See the section <em>Submitting Your Talk, Trainings, Helpdesk or Poster</em> of the CFP for further details.</p><p>Suggested size: 1500 chars.</p>'),
         widget=MarkEditWidget)

--- a/tests/test_cfp.py
+++ b/tests/test_cfp.py
@@ -328,3 +328,56 @@ class TestCFP(TestCase):
 
         assert talk.title == 'More about EPCON testing'
         assert 'love' in talk.tags.all().values_list('name', flat=True)
+
+    def test_allows_very_long_description(self):
+        assert Tag.objects.count() == 0
+        self.client.login(email='joedoe@example.com', password='password123')
+
+        VALIDATION_SUCCESSFUL_303 = 303
+
+        abstract = 'a' * 5000
+
+        talk_proposal = {
+            "type": "t_30",
+            'first_name': 'Joe',
+            'last_name': 'Doe',
+            "birthday": "2018-02-26",
+            'bio': "Python developer",
+            "title": "Testing EPCON CFP",
+            "abstract_short": "Short talk about testing CFP",
+            "abstract": abstract,
+            "level": "advanced",
+            "phone": "41331237",
+            "tags": "django, testing, slides",
+            "personal_agreement": True,
+            "slides_agreement": True,
+            "video_agreement": True,
+        }
+
+        profile_url = reverse("conference-myself-profile")
+        response = self.client.post(self.form_url, talk_proposal)
+        assert response.status_code == VALIDATION_SUCCESSFUL_303
+
+        talk = Talk.objects.first()
+
+        assert talk.abstracts.all()[0].body == abstract
+
+        # second proposal
+
+        talk_proposal = {
+            "type": "t_45",
+            "title": "More about EPCON testing",
+            "abstract_short": "Longer talk about testing",
+            "abstract": abstract,
+            "level": "advanced",
+            "tags": "love, testing, slides",
+            "slides_agreement": True,
+            "video_agreement": True,
+        }
+
+        response = self.client.post(self.form_url, talk_proposal)
+        assert response.status_code == VALIDATION_SUCCESSFUL_303
+
+        talk = Talk.objects.first()
+
+        assert talk.abstracts.all()[0].body == abstract


### PR DESCRIPTION
I've left the suggested limit to 1500, maybe we should improve the wording, something like:

`Suggested size: 1500 chars. Max size: 5000`

@alanderex what do you think?