### PR TITLE
Fix #619 – run migrations on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ python:
 install:
   - pip install -r requirements-dev.txt
 
-script: "py.test"
+script: "py.test -c pytest_ci.ini"

--- a/pytest_ci.ini
+++ b/pytest_ci.ini
@@ -1,3 +1,4 @@
 [pytest]
+# run with full migrations, increased verbosity (-vvv) and enabled stdout (-s)
 DJANGO_SETTINGS_MODULE=pycon.dev-settings
-addopts = --cov-config .coveragerc --cov ./ --cov-report term --profile-svg --durations=5
+addopts = --cov-config .coveragerc --cov ./ --cov-report term --profile-svg --durations=5 -vvv -s

--- a/pytest_ci.ini
+++ b/pytest_ci.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=pycon.dev-settings
+addopts = --cov-config .coveragerc --cov ./ --cov-report term --profile-svg --durations=5


### PR DESCRIPTION
Fixes #619 : run tests on travis using different pytest.ini - enabling migrations on CI