### PR TITLE
Fixes #656 - CSS for highlight is not visible

### DIFF
--- a/p3/static/p6/stylesheets/all.css
+++ b/p3/static/p6/stylesheets/all.css
@@ -271,7 +271,7 @@ a:hover, a:active { outline: 0; }
 
 ::-moz-selection { background-color: white; color: #146C47; text-shadow: none; }
 
-::selection { background-color: white; color: #146C47; text-shadow: none; }
+::selection { background-color: #006e44; color: white; text-shadow: none; }
 
 .swatch { margin: 0 0 1.5em 0; padding: 0; }
 


### PR DESCRIPTION
Currently the selection background-color and color, are set to exactly the same as the normal text, which makes sections undetectable.

This change, sets selected text and having the dark green background from the footer, which white text. Removing a selection rule altogether would also be fine.

I've only edited the css file I'm getting on the site, but there are repeats of similar rule, in a few places. See https://github.com/EuroPython/epcon/search?l=CSS&q=selection&type=