### PR TITLE
Remove Twitter widget from base template. It's not used anywhere.

### DIFF
--- a/templates/p3/base.html
+++ b/templates/p3/base.html
@@ -206,12 +206,13 @@
         }
     </script>
 
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+    <!-- No parallax this year...
     <script type="text/javascript">
         $('.discover-europython').parallax({
             speed : 0.3
         });
     </script>
+    -->
     <!-- @@TODO We should really use head.js -->
     <script type="text/javascript" src="{{ STATIC_URL }}p6/javascripts/vendor/bootstrap-min.js"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}p6/javascripts/nav-patterns/responsive-nav.min.js"></script>


### PR DESCRIPTION
Also disable parallax, which we don't use this year.