### PR TITLE
Fix spelling of euroython

### DIFF
--- a/documents/europython-mockups/blog-post.html
+++ b/documents/europython-mockups/blog-post.html
@@ -102,7 +102,7 @@
     <div class="blog-post">
 
 <rdf:rdf xmlns:trackback="http://madskills.com/public/xml/rss/module/trackback/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-<rdf:description trackback:ping="http://www.euroython.eu/blog/2010/12/12/roma-call-for-paper-codemotion-2011/trackback" dc:title="Become a Codemotion Speaker" dc:identifier="http://www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011" rdf:about="http://www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">
+<rdf:description trackback:ping="http://www.europython.eu/blog/2010/12/12/roma-call-for-paper-codemotion-2011/trackback" dc:title="Become a Codemotion Speaker" dc:identifier="http://www.europython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011" rdf:about="http://www.europython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">
 </rdf:description>
 
 
@@ -143,11 +143,11 @@ For information: <a href="http://www.codemotion.it/en">www.codemotion.it</a></p>
         <ul>
             <li>
                 <!-- delicious  -->
-                <img width="16" height="16" alt="Delicious" src="./static/i/delicious-16x16.png">&nbsp;<a onclick="window.open(this.href, 'sharer');return false;" title="Delicious" href="http://del.icio.us/post?v=4&amp;noui&amp;jump=close&amp;url=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Delicious</a>
+                <img width="16" height="16" alt="Delicious" src="./static/i/delicious-16x16.png">&nbsp;<a onclick="window.open(this.href, 'sharer');return false;" title="Delicious" href="http://del.icio.us/post?v=4&amp;noui&amp;jump=close&amp;url=http%3A//www.europython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Delicious</a>
             </li>
             <li>
                 <!-- reddit.com -->
-                <img width="16" height="16" alt="Reddit" src="./static/i/reddit-16x16.png">&nbsp;<a title="Reddit" onclick="window.open(this.href, 'sharer');return false;" href="http://reddit.com/submit?url=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Reddit</a>
+                <img width="16" height="16" alt="Reddit" src="./static/i/reddit-16x16.png">&nbsp;<a title="Reddit" onclick="window.open(this.href, 'sharer');return false;" href="http://reddit.com/submit?url=http%3A//www.europython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Reddit</a>
             </li>
         </ul>
     </div>
@@ -156,11 +156,11 @@ For information: <a href="http://www.codemotion.it/en">www.codemotion.it</a></p>
         <ul>
             <li>
                 <!-- twitter -->
-                <img width="16" height="16" alt="Twitter" src="./static/i/twitter-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Twitter" href="http://twitter.com/home?status=Become%20a%20Codemotion%20Speaker+http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Twitter</a>
+                <img width="16" height="16" alt="Twitter" src="./static/i/twitter-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Twitter" href="http://twitter.com/home?status=Become%20a%20Codemotion%20Speaker+http%3A//www.europython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Twitter</a>
             </li>
             <li>
                 <!-- friendfeed -->
-                <img width="16" height="16" alt="Friendfeed" src="./static/i/friendfeed-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Facebook" href="http://www.friendfeed.com/share?title=Become%20a%20Codemotion%20Speaker&amp;link=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Friendfeed</a>
+                <img width="16" height="16" alt="Friendfeed" src="./static/i/friendfeed-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Facebook" href="http://www.friendfeed.com/share?title=Become%20a%20Codemotion%20Speaker&amp;link=http%3A//www.europython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Friendfeed</a>
             </li>
         </ul>
     </div>
@@ -169,11 +169,11 @@ For information: <a href="http://www.codemotion.it/en">www.codemotion.it</a></p>
         <ul>
             <li>
                 <!-- facebook -->
-                <img width="16" height="16" alt="Facebook" src="./static/i/facebook-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Facebook" href="http://www.facebook.com/share.php?u=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Facebook</a>
+                <img width="16" height="16" alt="Facebook" src="./static/i/facebook-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="Facebook" href="http://www.facebook.com/share.php?u=http%3A//www.europython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011">Facebook</a>
             </li>
             <li>
                 <!-- stumbleupon -->
-                <img width="16" height="16" alt="StumbleUpon" src="./static/i/stumbleupon-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="StumbleUpon" href="http://www.stumbleupon.com/submit?url=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">StumbleUpon</a>
+                <img width="16" height="16" alt="StumbleUpon" src="./static/i/stumbleupon-16x16.png">&nbsp;<a onclick="window.open(this.href,'sharer');return false;" title="StumbleUpon" href="http://www.stumbleupon.com/submit?url=http%3A//www.europython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">StumbleUpon</a>
             </li>
         </ul>
     </div>
@@ -182,11 +182,11 @@ For information: <a href="http://www.codemotion.it/en">www.codemotion.it</a></p>
         <ul>
             <li>
                 <!-- digg.com -->
-                <img width="16" height="16" alt="digg" src="./static/i/digg-this-16x16.png">&nbsp;<a title="digg" onclick="window.open(this.href, 'sharer');return false;" href="http://digg.com/submit?phase=2&amp;url=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Digg this</a>
+                <img width="16" height="16" alt="digg" src="./static/i/digg-this-16x16.png">&nbsp;<a title="digg" onclick="window.open(this.href, 'sharer');return false;" href="http://digg.com/submit?phase=2&amp;url=http%3A//www.europython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;title=Become%20a%20Codemotion%20Speaker">Digg this</a>
             </li>
             <li>
                 <!-- newsvine -->
-                <img width="16" height="16" alt="Newsvine" src="./static/i/newsvine-16x16.png">&nbsp;<a title="Newsvine" onclick="window.open(this.href, 'sharer');return false;" href="http://www.newsvine.com/_tools/seed&amp;save?u=http%3A//www.euroython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;h=Become%20a%20Codemotion%20Speaker">Newsvine</a>
+                <img width="16" height="16" alt="Newsvine" src="./static/i/newsvine-16x16.png">&nbsp;<a title="Newsvine" onclick="window.open(this.href, 'sharer');return false;" href="http://www.newsvine.com/_tools/seed&amp;save?u=http%3A//www.europython.eu/blog/2010/12/12/rome-call-for-paper-codemotion-2011&amp;h=Become%20a%20Codemotion%20Speaker">Newsvine</a>
             </li>
         </ul>
     </div>
@@ -234,7 +234,7 @@ For information: <a href="http://www.codemotion.it/en">www.codemotion.it</a></p>
 
                 <div class="metadata">
 
-                        <span><a class="reply-comment" href="#">Reply</a> | </span><strong><a rel="nofollow" href="http://euroython.eu/">C8E</a></strong>,&nbsp;
+                        <span><a class="reply-comment" href="#">Reply</a> | </span><strong><a rel="nofollow" href="http://europython.eu/">C8E</a></strong>,&nbsp;
 
                         <span class="date">04 aprile 2010</span>&nbsp;<a href="#comment-80" title="Permalink a questo commento" class="permalink">#</a>
                 </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,8 +1,8 @@
-<!DOCTYPE html> 
-<html xml:lang="en" lang="en" xmlns="http://www.w3.org/1999/xhtml"> 
-<head> 
+<!DOCTYPE html>
+<html xml:lang="en" lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
     <meta charset="UTF-8" />
-    <title>Blam! A 5xx error occured</title>    
+    <title>Blam! A 5xx error occured</title>
     <style type="text/css">
 
 body {
@@ -38,7 +38,7 @@ blockquote {
   <h2>You found a secret castle.</h2>
   <h2>Unfortunately that's a 500 error page.</h2>
 <p>We are trying to find the bug that had caused it.</p>
-<p>The <a href="http://euroython.eu/">EuroPython</a> team &lt;<a href="mailto:info@euroython.eu">info@euroython.eu</a>&gt;</p>
+<p>The <a href="http://europython.eu/">EuroPython</a> team &lt;<a href="mailto:info@europython.eu">info@europython.eu</a>&gt;</p>
 
 <p><a href='/'>→ Click here to go back to the homepage ←</a></p>
 

--- a/templates/assopy/paypal_feedback_ok.html
+++ b/templates/assopy/paypal_feedback_ok.html
@@ -14,7 +14,7 @@
         {% if not ocomplete %}
         <h1>{% trans "Waiting for Paypal response..." %}</h1>
         <div>
-            <p>{% blocktrans with code=order.code url="mailto:helpdesk@euroython.eu" %}
+            <p>{% blocktrans with code=order.code url="mailto:helpdesk@europython.eu" %}
                 Are you waiting for too long? <a href="{{ url }}">Write to us</a>
                 specifying your order number {{ code }}
             {% endblocktrans %}</p>

--- a/templates/assopy/profile.html
+++ b/templates/assopy/profile.html
@@ -82,7 +82,7 @@
                                         parent.remove();
                                     },
                                     error: function(xhr, status, error) {
-                                        alert('{% trans "Cannot remove the requested account, please contact info@euroython.eu for assistance" %}');
+                                        alert('{% trans "Cannot remove the requested account, please contact info@europython.eu for assistance" %}');
                                     }
                                 });
                             });

--- a/templates/p3/sprints.html
+++ b/templates/p3/sprints.html
@@ -53,7 +53,7 @@
                 setup_trigger_overlay($('.trigger-overlay', wrapper));
             },
             error: function() {
-                alert('{% trans "Cannot save the form.\nUse the web chat, or contact info@euroython.eu, for assistance." %}');
+                alert('{% trans "Cannot save the form.\nUse the web chat, or contact info@europython.eu, for assistance." %}');
             }
         });
     });

--- a/templates/p3/tickets.html
+++ b/templates/p3/tickets.html
@@ -82,7 +82,7 @@
         }
     });
     function _error() {
-        {% trans "Cannot save the ticket.\nUse the web chat, or contact info@euroython.eu, for assistance." as t_error %}
+        {% trans "Cannot save the ticket.\nUse the web chat, or contact info@europython.eu, for assistance." as t_error %}
         alert("{{ t_error|escapejs }}");
     }
     function _success(message, container) {


### PR DESCRIPTION
Having reached this 500 during the purchase process (email sent to helpdesk), the 500 page lists a non-existent email address of `info@euroython.eu` (missing `p`!)

![image](https://user-images.githubusercontent.com/167319/40777945-44a82b2c-64c7-11e8-9e38-1438e39f6426.png)

Resulting is this mail error:

![image](https://user-images.githubusercontent.com/167319/40777852-f28ff6c6-64c6-11e8-8da9-cb9a986717e8.png)

This PR fixes the misspellings.