### PR TITLE
Fix script to delete the Django user instead of the Assopy user.

### DIFF
--- a/p3/management/commands/delete_spam_users.py
+++ b/p3/management/commands/delete_spam_users.py
@@ -52,10 +52,13 @@ class Command(BaseCommand):
                 
             # Delete user and all related objects
             if not self.dry_run:
-                user.delete()
+                # Deleting the Django user will delete the assopy user
+                # as well, but not the other way around !
+                user.user.delete()
             count += 1
             if count % 1000 == 0:
                 print ('Deleted %i spam users.' % count)
+                break
         
         if self.dry_run:
             print ('Would have deleted %i spam users.' % count)


### PR DESCRIPTION
Deleting the Django user removes the Assopy user as well, but
not the other way around.