### PR TITLE
Fix assigned tickets not editable

### DIFF
--- a/p3/templatetags/p3.py
+++ b/p3/templatetags/p3.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import mimetypes
 import os
@@ -166,7 +166,7 @@ def render_ticket(context, ticket):
             single_day=ticket.fare.code[2] == 'D',
         )
         if inst and inst.assigned_to:
-            blocked = inst.assigned_to != user.email
+            blocked = inst.assigned_to.lower() != user.email.lower()
         else:
             blocked = False
     elif ticket.fare.code in ('SIM01',):

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -655,6 +655,7 @@ def test_export_invoice_csv(client):
 
     assert next(iter_column) == '2018-05-05'
     assert next(iter_column) == invoice1.order.user.user.get_full_name()
+    assert next(iter_column) == invoice1.order.card_name
 
     next(iter_column)   # ignore the address
     assert next(iter_column) == invoice1.order.country.name

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -393,6 +393,9 @@ class TestTicketManagementScenarios(TestCase):
         response = self.client.get(self.p3_tickets_url)
         self.assertContains(response, self.ticket_url)
 
+        # And that it has an "Edit this ticket"
+        self.assertContains(response, "Edit this ticket")
+
     def test_reclaim_ticket(self):
         assert self.tc.assigned_to == self.MAIN_USER_EMAIL
         self.client.post(self.ticket_url, {


### PR DESCRIPTION
This fixes that tickets assigned with an email address with a case that differs from that of the user are not editable