### PR TITLE
Fix video schedule to allow having multiple events per talk.

### DIFF
--- a/p3/management/commands/attendify_schedule_xlsx.py
+++ b/p3/management/commands/attendify_schedule_xlsx.py
@@ -59,8 +59,9 @@ else:
 # plenary room in this case.
 PLENARY_ROOM = 'Smarkets'
 
-# Breaks have more than 3 tracks assigned.
-BREAK_ROOM = 'Lennox'
+# Breaks have more than 3 tracks assigned. Since this changes between
+# the days, we don't set the room name.
+BREAK_ROOM = ''
 
 ### Helpers
 

--- a/p3/management/commands/video_schedule_xlsx.py
+++ b/p3/management/commands/video_schedule_xlsx.py
@@ -356,10 +356,13 @@ class Command(BaseCommand):
 
             # Add talks from bag to data
             for talk in bag:
-                add_event(data,
-                          talk=talk,
-                          talk_events=talk_events,
-                          session_type=type_name)
+                for event in talk.get_event_list():
+                    # A talk may have multiple events associated with it
+                    add_event(data,
+                              talk=talk,
+                              event=event,
+                              talk_events=talk_events,
+                              session_type=type_name)
 
         # Add events which are not talks
         for schedule in models.Schedule.objects.filter(conference=conference):


### PR DESCRIPTION
Change the break room in the Attendify schedule to '', since this
would otherwise cause confusion.