### PR TITLE
Rename django.contrib.admin.util to django.contrib.admin.utils

### DIFF
--- a/assopy/admin.py
+++ b/assopy/admin.py
@@ -157,7 +157,7 @@ class OrderAdmin(admin.ModelAdmin):
     _total_payed.short_description = 'Payed'
 
     def _invoice(self, o):
-        from django.contrib.admin.util import quote
+        from django.contrib.admin.utils import quote
         output = []
         # MAL: PDF generation is slower, so default to HTML
         if 1 or dsettings.DEBUG:

--- a/assopy/models.py
+++ b/assopy/models.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from django import dispatch
 from django.conf import settings as dsettings
 from django.contrib import auth
-from django.contrib.admin.util import quote
+from django.contrib.admin.utils import quote
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.db import models

--- a/assopy/views.py
+++ b/assopy/views.py
@@ -9,7 +9,7 @@ from django import http
 from django.conf import settings as dsettings
 from django.contrib import auth
 from django.contrib import messages
-from django.contrib.admin.util import unquote
+from django.contrib.admin.utils import unquote
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404


### PR DESCRIPTION
More work on #576 - rename `django.contrib.admin.util` to `django.contrib.admin.utils`

The old name disappears in Django 1.9