### PR TITLE
Fix mismatching requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ ecdsa==0.13
 -e git+https://github.com/dcramer/django-paypal.git#egg=django_paypal-master
 gunicorn==19.5.0
 html2text==2015.2.18
-html5lib==0.95
+html5lib==0.999
 httplib2==0.9
 lxml==3.4.2
 markdown2==2.3.5
@@ -33,7 +33,7 @@ paramiko==1.17.6
 Pillow==2.6.1
 polib==1.0.6
 Pygments==2.0.2
-PyJWT==0.4.1
+PyJWT==1.0.1
 python-memcached==1.48
 python-oembed==0.2.1
 python-openid==2.2.5
@@ -45,7 +45,7 @@ requests==2.5.3
 responses==0.8.1
 requests-oauthlib==0.4.2
 simplejson==3.6.5
-six==1.9.0
+six==1.10.0
 stripe==1.19.1
 suds==0.4
 Unidecode==0.04.17


### PR DESCRIPTION
The following message appears when running pip install:

> django-rosetta 0.7.13 has requirement polib>=1.0.6, but you'll have polib 1.0.4 which is incompatible.
> weasyprint 0.29 has requirement html5lib>=0.999, but you'll have html5lib 0.95 which is incompatible.
> faker 0.8.17 has requirement six>=1.10, but you'll have six 1.9.0 which is incompatible.
> python-social-auth 0.2.9 has requirement PyJWT>=1.0.0, but you'll have pyjwt 0.4.1 which is incompatible.