### PR TITLE
No more Django 1.9 deprecation warnings

### DIFF
--- a/hcomments/models.py
+++ b/hcomments/models.py
@@ -13,6 +13,9 @@ class HComment(MPTTModel, Comment):
     parent = models.ForeignKey('self', null=True, blank=True, related_name='children')
     tree = TreeManager()
 
+    class Meta:
+        app_label = 'hcomments'
+
 
 class ThreadSubscriptionManager(models.Manager):
     def unsubscribe(self, object, user):
@@ -42,3 +45,4 @@ class ThreadSubscription(models.Model):
 
     class Meta:
         unique_together = ('user', 'object_id', 'content_type')
+        app_label = 'hcomments'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=pycon.dev-settings
 addopts = --nomigrations --cov-config .coveragerc --cov ./ --cov-report term --cov-report html --profile-svg --durations=5 -n auto
-filterwarnings = 
-    ignore::django.utils.deprecation.RemovedInDjango19Warning

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ akismet==0.2.0
 BeautifulSoup==3.2.1
 cmsplugin-filer==1.1.3
 Django==1.8.16
-django-appconf==1.0.2
 django-authority==0.11 #serve a django-page-cms ma non è incluso nelle sue dipendenze
 django-classy-tags==0.8.0
 django-cms==3.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ akismet==0.2.0
 BeautifulSoup==3.2.1
 cmsplugin-filer==1.1.3
 Django==1.8.16
-django-authority==0.11 #serve a django-page-cms ma non è incluso nelle sue dipendenze
+django-authority==0.13.1
 django-classy-tags==0.8.0
 django-cms==3.5.2
 djangocms-admin-style==1.2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-crontab==0.4.2
 django-filebrowser-no-grappelli==3.6.2
 django-filer==1.2.5
 django-markitup==2.2.2
-django-mptt==0.8.6
+django-mptt==0.8.7
 django-polymorphic==0.8.1
 django-rosetta==0.7.13
 django-sekizai==0.10.0
@@ -31,7 +31,7 @@ markdown2==2.3.5
 oauthlib==0.7.2
 paramiko==1.17.6
 Pillow==2.6.1
-polib==1.0.4
+polib==1.0.6
 Pygments==2.0.2
 PyJWT==0.4.1
 python-memcached==1.48


### PR DESCRIPTION
Clean up the final `RemovedInDjango19` deprecation warnings found when running `manage.py shell`

- django-appconf isn't used, so :fire: it
- django-authority, django-mptt and polib need version bumps
- models in hcomments need app_label so Django knows where they're used