### PR TITLE
Install pip requirements after system requirements in provision.sh

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -14,9 +14,6 @@ title "Make virtualenv"
 virtualenv -p python2.7 ../epcon-env
 source ../epcon-env/bin/activate
 
-title "PIP install dev requirements"
-pip install -r requirements/dev.txt
-
 title "install platform requirements"
 if [[ `uname` == "Darwin" ]]; then
     brew install cairo pango
@@ -26,6 +23,10 @@ if [[ -x "$(command -v lsb_release)" && `lsb_release -i` =~ $ubuntu_regex ]]; th
     echo 'Installing missing Ubuntu packages'
     sudo apt-get install libxml2-dev libxslt1-dev python-dev
 fi
+
+
+title "PIP install dev requirements"
+pip install -r requirements/dev.txt
 
 title "Copy settings"
 [[ -e pycon/settings_locale.py ]] || cp pycon/settings_locale.py.in pycon/settings_locale.py


### PR DESCRIPTION
To make sure that we have install-time libraries (and not just runtime libraries) available. Important for lxml and couple of other things.