### PR TITLE
Fix timezone-related test and model issues.

### DIFF
--- a/assopy/admin.py
+++ b/assopy/admin.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from collections import defaultdict
-from datetime import datetime
 
 from django import forms
 from django import http
@@ -10,6 +9,7 @@ from django.contrib import admin
 from django.core import urlresolvers
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
+from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.template.response import TemplateResponse
 
@@ -638,7 +638,7 @@ class RefundAdmin(admin.ModelAdmin):
                     cn = models.CreditNote(assopy_id=item['assopy_id'])
                     total = sum(refund.items.all().values_list('price', flat=True))
                     cn.price = total
-                    cn.emit_date = datetime.now()
+                    cn.emit_date = timezone.now()
                     cn.code = item['code']
                     cn.invoice = item['invoice']
                     cn.save()

--- a/assopy/models.py
+++ b/assopy/models.py
@@ -270,7 +270,7 @@ class User(models.Model):
 
         https://github.com/EuroPython/epcon/issues/592
         """
-        return self.orders.filter(created__gte=date(2018, 1, 1))
+        return self.orders.filter(created__gte=timezone.make_aware(datetime(2018, 1, 1)))
 
     def tickets(self):
         tickets = []
@@ -1095,7 +1095,7 @@ class Refund(models.Model):
             except Refund.DoesNotExist:
                 pass
         if self.status in ('rejected', 'refunded') and self.status != old:
-            self.done = datetime.now()
+            self.done = now()
         if old and self.status != old:
             o = self.items.all()[0].order
             log.info(

--- a/assopy/views.py
+++ b/assopy/views.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
-import json
 import logging
 import urllib
-from datetime import datetime
 
 from django import http
 from django.conf import settings as dsettings
-from django.contrib import auth
 from django.contrib import messages
 from django.contrib.admin.utils import unquote
 from django.contrib.auth.decorators import login_required
@@ -15,12 +12,12 @@ from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
 from django.shortcuts import render_to_response
 from django.template import RequestContext
+from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 
 from assopy import forms as aforms
 from assopy import models
 from assopy import settings
-from assopy import utils as autils
 from common.decorators import render_to_json, render_to_template
 from common.http import PdfResponse
 from conference.invoicing import VAT_NOT_AVAILABLE_PLACEHOLDER
@@ -176,7 +173,7 @@ def paypal_billing(request, code):
     log.debug('Paypal billing request (code %s): %s', code, request.environ)
     o = get_object_or_404(models.Order, code=code.replace('-', '/'))
     if o.total() == 0:
-        o.confirm_order(datetime.now())
+        o.confirm_order(timezone.now())
         return HttpResponseRedirectSeeOther(reverse('assopy-paypal-feedback-ok', kwargs={'code': code}))
     form = aforms.PayPalForm(o)
     return HttpResponseRedirectSeeOther("%s?%s" % (form.paypal_url(), form.as_url_args()))
@@ -188,7 +185,7 @@ def paypal_cc_billing(request, code):
     log.debug('Paypal CC billing request (code %s): %s', code, request.environ)
     o = get_object_or_404(models.Order, code=code.replace('-', '/'))
     if o.total() == 0:
-        o.confirm_order(datetime.now())
+        o.confirm_order(timezone.now())
         return HttpResponseRedirectSeeOther(reverse('assopy-paypal-feedback-ok', kwargs={'code': code}))
     form = aforms.PayPalForm(o)
     cc_data = {

--- a/tests/test_cfp.py
+++ b/tests/test_cfp.py
@@ -275,8 +275,8 @@ class TestCFP(TestCase):
         assert Tag.objects.count() == 0
 
     def test_ignores_new_tags_keeping_predefined_ones(self):
-        ConferenceTag.objects.create(name='django')
-        ConferenceTag.objects.create(name='love')
+        ConferenceTag.objects.create(name=u'django')
+        ConferenceTag.objects.create(name=u'love')
 
         assert Talk.objects.all().count() == 0
         assert ConferenceTag.objects.count() == 2

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals, absolute_import
 
 import csv
 import decimal
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 import random
 import json
@@ -14,6 +14,7 @@ from pytest import mark
 from django.core.urlresolvers import reverse
 from django.core.management import call_command
 from django.conf import settings
+from django.utils import timezone
 
 from django_factory_boy import auth as auth_factories
 from freezegun import freeze_time
@@ -22,7 +23,6 @@ import responses
 from assopy.models import Country, Invoice, Order, Vat
 from assopy.tests.factories.user import UserFactory as AssopyUserFactory
 from assopy.stripe.tests.factories import FareFactory, OrderFactory
-# from common.http import PdfResponse
 from conference.models import AttendeeProfile, Ticket, Fare
 from conference import settings as conference_settings
 from conference import invoicing  # for monkey patching below
@@ -33,7 +33,6 @@ from conference.invoicing import (
     VAT_NOT_AVAILABLE_PLACEHOLDER,
     upgrade_invoice_placeholder_to_real_invoice,
     CSV_2018_REPORT_COLUMNS,
-    # render_invoice_as_html,
 )
 from conference.currencies import (
     DAILY_ECB_URL,
@@ -146,12 +145,12 @@ def test_592_dont_display_invoices_for_years_before_2018(client):
 
     order2017 = Order(user=assopy_user, code=order_code_2017)
     order2017.save()
-    order2017.created = date(2017, 12, 31)
+    order2017.created = timezone.make_aware(datetime(2017, 12, 31))
     order2017.save()
 
     order2018 = Order(user=assopy_user, code=order_code_2018)
     order2018.save()
-    order2018.created = date(2018, 1, 1)
+    order2018.created = timezone.make_aware(datetime(2018, 1, 1))
     order2018.save()
 
     Invoice.objects.create(
@@ -312,7 +311,7 @@ def test_invoices_from_buying_tickets(client):
     # no invoices
     assert Invoice.objects.all().count() == 0
     # static date, because of #592 choosing something in 2018
-    SOME_RANDOM_DATE = date(2018, 1, 1)
+    SOME_RANDOM_DATE = timezone.make_aware(datetime(2018, 1, 1))
     order.confirm_order(SOME_RANDOM_DATE)
     assert order.payment_date == SOME_RANDOM_DATE
 
@@ -400,7 +399,6 @@ def test_invoices_from_buying_tickets(client):
 
 
 def create_order_and_invoice(assopy_user, fare, keep_as_placeholder=False):
-    today = date.today()
     order = OrderFactory(user=assopy_user, items=[(fare, {'qty': 1})])
 
     with responses.RequestsMock() as rsps:
@@ -408,7 +406,7 @@ def create_order_and_invoice(assopy_user, fare, keep_as_placeholder=False):
         rsps.add(responses.GET, DAILY_ECB_URL, body=EXAMPLE_ECB_DAILY_XML)
         fetch_and_store_latest_ecb_exrates()
 
-    order.confirm_order(today)
+    order.confirm_order(timezone.now())
 
     # confirm_order by default creates placeholders, but for most of the tests
     # we can upgrade them to proper invoices anyway.
@@ -567,7 +565,7 @@ def test_create_invoice_with_many_items(client):
         rsps.add(responses.GET, DAILY_ECB_URL, body=EXAMPLE_ECB_DAILY_XML)
         fetch_and_store_latest_ecb_exrates()
 
-    order.confirm_order(date.today())
+    order.confirm_order(timezone.now())
     # invoice = Invoice.objects.get()
     # serve_response(PdfResponse(
     #     filename="some-invoice.pdf",

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -3,20 +3,17 @@
 from __future__ import unicode_literals
 
 from datetime import date
-# from httplib import OK as HTTP_OK_200
 
+import responses
+from freezegun import freeze_time
 from pytest import mark
+
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils import timezone
 
-# from django_factory_boy import auth as auth_factories
-from freezegun import freeze_time
-import responses
-
 from assopy.models import Vat, Order, Country, Refund, Invoice
-# from assopy.tests.factories.user import UserFactory as AssopyUserFactory
 from conference.fares import (
     pre_create_typical_fares_for_conference,
     set_early_bird_fare_dates,
@@ -216,7 +213,7 @@ class TestBuyingTickets(TestCase):
             assert order.total() == 630  # because 210 per ticket
             assert not order._complete
 
-            order.confirm_order(date.today())
+            order.confirm_order(timezone.now())
             assert order._complete
 
             invoice = Invoice.objects.get()
@@ -363,7 +360,7 @@ class TestTicketManagementScenarios(TestCase):
 
     def test_assign_ticket_to_another_user_case_insensitive(self):
         # we need to confirm the order for the tickets to display in the profile
-        self.order.confirm_order(date.today())
+        self.order.confirm_order(timezone.now())
 
         other_user = make_user(self.OTHER_USER_EMAIL)
 
@@ -419,8 +416,6 @@ class TestTicketManagementScenarios(TestCase):
         assert self.tc.diet              == 'other'
         assert self.tc.shirt_size        == 'fm'
         assert self.tc.python_experience == 5
-
-
 
     def test_reclaim_ticket(self):
         assert self.tc.assigned_to == self.MAIN_USER_EMAIL
@@ -522,7 +517,7 @@ class TestTicketManagementScenarios(TestCase):
 
         assert Invoice.objects.all().count() == 0
 
-        self.order.confirm_order(timezone.now().date())
+        self.order.confirm_order(timezone.now())
 
         assert Invoice.objects.all().count() == 1
 


### PR DESCRIPTION
Tests no longer generate naive datetime warnings.