### PR TITLE
Remove django 20 warnings

### DIFF
--- a/assopy/middleware.py
+++ b/assopy/middleware.py
@@ -4,6 +4,8 @@ import sys, traceback
 from io import StringIO
 
 from django.conf import settings
+from django.utils.deprecation import MiddlewareMixin
+
 
 def dump_exc_plus(exclude=None):
     """
@@ -45,7 +47,8 @@ def dump_exc_plus(exclude=None):
 
     return s.getvalue()
 
-class DebugInfo(object):
+
+class DebugInfo(MiddlewareMixin):
     """
     Adds user details to request context on receiving an exception, so that
     they show up in the error emails.

--- a/assopy/migrations/0002_auto_20180408_2337.py
+++ b/assopy/migrations/0002_auto_20180408_2337.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+import django.db.models.deletion
 from django.db import migrations, models
 from django.conf import settings
 
@@ -17,12 +18,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='vatfare',
             name='fare',
-            field=models.ForeignKey(to='conference.Fare'),
+            field=models.ForeignKey(to='conference.Fare', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='vatfare',
             name='vat',
-            field=models.ForeignKey(to='assopy.Vat'),
+            field=models.ForeignKey(to='assopy.Vat', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='vat',
@@ -32,47 +33,47 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='useroauthinfo',
             name='user',
-            field=models.ForeignKey(related_name='oauth_infos', to='assopy.User'),
+            field=models.ForeignKey(related_name='oauth_infos', to='assopy.User', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='useridentity',
             name='user',
-            field=models.ForeignKey(related_name='identities', to='assopy.User'),
+            field=models.ForeignKey(related_name='identities', to='assopy.User', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='user',
             name='country',
-            field=models.ForeignKey(verbose_name='Country', blank=True, to='assopy.Country', null=True),
+            field=models.ForeignKey(verbose_name='Country', blank=True, to='assopy.Country', null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='user',
             name='user',
-            field=models.OneToOneField(related_name='assopy_user', to=settings.AUTH_USER_MODEL),
+            field=models.OneToOneField(related_name='assopy_user', to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='token',
             name='user',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='refundorderitem',
             name='orderitem',
-            field=models.ForeignKey(to='assopy.OrderItem'),
+            field=models.ForeignKey(to='assopy.OrderItem', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='refundorderitem',
             name='refund',
-            field=models.ForeignKey(to='assopy.Refund'),
+            field=models.ForeignKey(to='assopy.Refund', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='refund',
             name='credit_note',
-            field=models.OneToOneField(null=True, blank=True, to='assopy.CreditNote'),
+            field=models.OneToOneField(null=True, blank=True, to='assopy.CreditNote', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='refund',
             name='invoice',
-            field=models.ForeignKey(to='assopy.Invoice', null=True),
+            field=models.ForeignKey(to='assopy.Invoice', null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='refund',
@@ -82,57 +83,57 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='orderitem',
             name='order',
-            field=models.ForeignKey(to='assopy.Order'),
+            field=models.ForeignKey(to='assopy.Order', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='orderitem',
             name='ticket',
-            field=models.OneToOneField(null=True, blank=True, to='conference.Ticket'),
+            field=models.OneToOneField(null=True, blank=True, to='conference.Ticket', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='orderitem',
             name='vat',
-            field=models.ForeignKey(to='assopy.Vat'),
+            field=models.ForeignKey(to='assopy.Vat', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='order',
             name='country',
-            field=models.ForeignKey(verbose_name='Country', to='assopy.Country', null=True),
+            field=models.ForeignKey(verbose_name='Country', to='assopy.Country', null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='order',
             name='user',
-            field=models.ForeignKey(related_name='orders', to='assopy.User'),
+            field=models.ForeignKey(related_name='orders', to='assopy.User', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='invoicelog',
             name='invoice',
-            field=models.ForeignKey(to='assopy.Invoice', null=True),
+            field=models.ForeignKey(to='assopy.Invoice', null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='invoicelog',
             name='order',
-            field=models.ForeignKey(to='assopy.Order', null=True),
+            field=models.ForeignKey(to='assopy.Order', null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='invoice',
             name='order',
-            field=models.ForeignKey(related_name='invoices', to='assopy.Order'),
+            field=models.ForeignKey(related_name='invoices', to='assopy.Order', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='invoice',
             name='vat',
-            field=models.ForeignKey(to='assopy.Vat'),
+            field=models.ForeignKey(to='assopy.Vat', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='creditnote',
             name='invoice',
-            field=models.ForeignKey(related_name='credit_notes', to='assopy.Invoice'),
+            field=models.ForeignKey(related_name='credit_notes', to='assopy.Invoice', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='coupon',
             name='conference',
-            field=models.ForeignKey(to='conference.Conference'),
+            field=models.ForeignKey(to='conference.Conference', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='coupon',
@@ -142,7 +143,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='coupon',
             name='user',
-            field=models.ForeignKey(blank=True, to='assopy.User', null=True),
+            field=models.ForeignKey(blank=True, to='assopy.User', null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AlterUniqueTogether(
             name='vatfare',

--- a/assopy/models.py
+++ b/assopy/models.py
@@ -25,7 +25,7 @@ from assopy import settings
 from assopy.utils import send_email
 from common import django_urls
 from conference.currencies import normalize_price
-from conference.models import Ticket
+from conference.models import Ticket, Fare
 from conference.users import generate_random_username
 from email_template import utils
 
@@ -350,7 +350,7 @@ class Coupon(models.Model):
     value = models.CharField(max_length=8, help_text='importo, eg: 10, 15%, 8.5')
 
     user = models.ForeignKey(User, null=True, blank=True, on_delete=models.CASCADE)
-    fares = models.ManyToManyField('conference.Fare', blank=True)
+    fares = models.ManyToManyField(Fare, blank=True)
 
     def __str__(self):
         return '%s (%s)' % (self.code, self.value)
@@ -570,7 +570,7 @@ class OrderQuerySet(models.QuerySet):
 
 
 class Vat(models.Model):
-    fares = models.ManyToManyField('conference.fare',
+    fares = models.ManyToManyField(Fare,
                                    through='VatFare',
                                    null=True, blank=True)
     value = models.DecimalField(max_digits=2, decimal_places=0)
@@ -582,7 +582,7 @@ class Vat(models.Model):
 
 
 class VatFare(models.Model):
-    fare = models.ForeignKey('conference.fare', on_delete=models.CASCADE)
+    fare = models.ForeignKey(Fare, on_delete=models.CASCADE)
     vat = models.ForeignKey(Vat, on_delete=models.CASCADE)
 
     class Meta:
@@ -976,7 +976,7 @@ class CreditNote(models.Model):
 
 
 class RefundOrderItem(models.Model):
-    orderitem = models.ForeignKey('assopy.OrderItem', on_delete=models.CASCADE)
+    orderitem = models.ForeignKey(OrderItem, on_delete=models.CASCADE)
     refund = models.ForeignKey('assopy.Refund', on_delete=models.CASCADE)
 
     class Meta:

--- a/assopy/models.py
+++ b/assopy/models.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 
 from django import dispatch
 from django.conf import settings as dsettings
-from django.contrib import auth
+from django.contrib.auth import get_user_model
 from django.contrib.admin.utils import quote
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
@@ -117,7 +117,7 @@ class Token(models.Model, django_urls.UrlMixin):
     """
     token = models.CharField(max_length=36, primary_key=True)
     ctype = models.CharField(max_length=1)
-    user = models.ForeignKey(auth.models.User, null=True)
+    user = models.ForeignKey(get_user_model(), null=True, on_delete=models.CASCADE)
     payload = models.TextField(blank='')
     created = models.DateTimeField(auto_now_add=True)
 
@@ -148,9 +148,9 @@ class UserManager(models.Manager):
             username = generate_random_username()
 
         if is_admin:
-            duser = auth.models.User.objects.create_superuser(username, email, password=password)
+            duser = get_user_model().objects.create_superuser(username, email, password=password)
         else:
-            duser = auth.models.User.objects.create_user(username, email, password=password)
+            duser = get_user_model().objects.create_user(username, email, password=password)
 
         duser.first_name = first_name
         duser.last_name = last_name
@@ -230,7 +230,7 @@ class User(models.Model):
     bultin django one from django.contrib.auth.models; This model is often
     referred to in other places as 'AssopyUser' for clarity.
     """
-    user = models.OneToOneField("auth.User", related_name='assopy_user')
+    user = models.OneToOneField(get_user_model(), related_name='assopy_user', on_delete=models.CASCADE)
     token = models.CharField(max_length=36, unique=True, null=True, blank=True)
     assopy_id = models.CharField(max_length=22, null=True, unique=True)
 
@@ -243,7 +243,7 @@ class User(models.Model):
     cf_code = models.CharField(
         _('Fiscal Code'), max_length=16, blank=True,
         help_text=_('Needed only for Italian customers'))
-    country = models.ForeignKey(Country, verbose_name=_('Country'), null=True, blank=True)
+    country = models.ForeignKey(Country, verbose_name=_('Country'), null=True, blank=True, on_delete=models.CASCADE)
     address = models.CharField(
         _('Address and City'),
         max_length=150,
@@ -325,7 +325,7 @@ class UserIdentityManager(models.Manager):
 
 class UserIdentity(models.Model):
     identifier = models.CharField(max_length=255, primary_key=True)
-    user = models.ForeignKey(User, related_name='identities')
+    user = models.ForeignKey(User, related_name='identities', on_delete=models.CASCADE)
     provider = models.CharField(max_length=255)
     display_name = models.TextField(blank=True)
     gender = models.CharField(max_length=10, blank=True)
@@ -340,7 +340,7 @@ class UserIdentity(models.Model):
 
 
 class Coupon(models.Model):
-    conference = models.ForeignKey('conference.Conference')
+    conference = models.ForeignKey('conference.Conference', on_delete=models.CASCADE)
     code = models.CharField(max_length=10)
     start_validity = models.DateField(null=True, blank=True)
     end_validity = models.DateField(null=True, blank=True)
@@ -349,7 +349,7 @@ class Coupon(models.Model):
     description = models.CharField(max_length=100, blank=True)
     value = models.CharField(max_length=8, help_text='importo, eg: 10, 15%, 8.5')
 
-    user = models.ForeignKey(User, null=True, blank=True)
+    user = models.ForeignKey(User, null=True, blank=True, on_delete=models.CASCADE)
     fares = models.ManyToManyField('conference.Fare', blank=True)
 
     def __str__(self):
@@ -582,8 +582,8 @@ class Vat(models.Model):
 
 
 class VatFare(models.Model):
-    fare = models.ForeignKey('conference.fare')
-    vat = models.ForeignKey(Vat)
+    fare = models.ForeignKey('conference.fare', on_delete=models.CASCADE)
+    vat = models.ForeignKey(Vat, on_delete=models.CASCADE)
 
     class Meta:
         unique_together =('fare', 'vat')
@@ -618,7 +618,7 @@ ENABLED_ORDER_PAYMENT = (
 class Order(models.Model):
     code = models.CharField(max_length=20, null=True)
     assopy_id = models.CharField(max_length=22, null=True, unique=True, blank=True)
-    user = models.ForeignKey(User, related_name='orders')
+    user = models.ForeignKey(User, related_name='orders', on_delete=models.CASCADE)
     created = models.DateTimeField(auto_now_add=True)
     method = models.CharField(max_length=6, choices=ORDER_PAYMENT)
     payment_url = models.TextField(blank=True)
@@ -640,7 +640,7 @@ class Order(models.Model):
     cf_code = models.CharField(_('Fiscal Code'), max_length=16, blank=True)
     # la country deve essere null perché un ordine può essere creato via admin
     # e in quel caso non è detto che si conosca
-    country = models.ForeignKey(Country, verbose_name=_('Country'), null=True)
+    country = models.ForeignKey(Country, verbose_name=_('Country'), null=True, on_delete=models.CASCADE)
     address = models.CharField(_('Address'), max_length=150, blank=True)
 
     stripe_charge_id = models.CharField(_('Charge Stripe ID'), max_length=64, unique=True, null=True)
@@ -759,14 +759,14 @@ class Order(models.Model):
 
 
 class OrderItem(models.Model):
-    order = models.ForeignKey(Order)
-    ticket = models.OneToOneField('conference.ticket', null=True, blank=True)
+    order = models.ForeignKey(Order, on_delete=models.CASCADE)
+    ticket = models.OneToOneField('conference.ticket', null=True, blank=True, on_delete=models.CASCADE)
     code = models.CharField(max_length=10)
     price = models.DecimalField(max_digits=6, decimal_places=2)
     description = models.CharField(max_length=100, blank=True)
     # aggiungo un campo per iva... poi potra essere un fk ad un altra tabella
     # o venire copiato da conference
-    vat = models.ForeignKey(Vat)
+    vat = models.ForeignKey(Vat, on_delete=models.CASCADE)
 
     def invoice(self):
         """
@@ -831,8 +831,8 @@ order_created.connect(_order_feedback)
 
 class InvoiceLog(models.Model):
     code =  models.CharField(max_length=20, unique=True)
-    order = models.ForeignKey(Order, null=True)
-    invoice = models.ForeignKey('Invoice', null=True)
+    order = models.ForeignKey(Order, null=True, on_delete=models.CASCADE)
+    invoice = models.ForeignKey('Invoice', null=True, on_delete=models.CASCADE)
     date = models.DateTimeField(auto_now_add=True)
 
 
@@ -840,7 +840,7 @@ class Invoice(models.Model):
 
     PLACEHOLDER_EXRATE_DATE = date(2000, 1, 1)
 
-    order = models.ForeignKey(Order, related_name='invoices')
+    order = models.ForeignKey(Order, related_name='invoices', on_delete=models.CASCADE)
     code = models.CharField(max_length=20, null=True, unique=True)
     assopy_id = models.CharField(max_length=22, unique=True,
                                  null=True, blank=True)
@@ -871,7 +871,7 @@ class Invoice(models.Model):
     # indica il tipo di regime iva associato alla fattura perche vengono
     # generate più fatture per ogni ordine contente orderitems con diverso
     # regime fiscale
-    vat = models.ForeignKey(Vat)
+    vat = models.ForeignKey(Vat, on_delete=models.CASCADE)
 
     note = models.TextField(
         blank=True,
@@ -953,7 +953,7 @@ if 'paypal.standard.ipn' in dsettings.INSTALLED_APPS:
 
 
 class CreditNote(models.Model):
-    invoice = models.ForeignKey(Invoice, related_name='credit_notes')
+    invoice = models.ForeignKey(Invoice, related_name='credit_notes', on_delete=models.CASCADE)
     code = models.CharField(max_length=20, unique=True)
     assopy_id =  models.CharField(max_length=22, null=True)
     emit_date = models.DateField()
@@ -976,8 +976,8 @@ class CreditNote(models.Model):
 
 
 class RefundOrderItem(models.Model):
-    orderitem = models.ForeignKey('assopy.OrderItem')
-    refund = models.ForeignKey('assopy.Refund')
+    orderitem = models.ForeignKey('assopy.OrderItem', on_delete=models.CASCADE)
+    refund = models.ForeignKey('assopy.Refund', on_delete=models.CASCADE)
 
     class Meta:
         unique_together = (('orderitem', 'refund'),)
@@ -1027,11 +1027,11 @@ REFUND_STATUS = (
 
 
 class Refund(models.Model):
-    invoice = models.ForeignKey(Invoice, null=True)
+    invoice = models.ForeignKey(Invoice, null=True, on_delete=models.CASCADE)
     items = models.ManyToManyField(OrderItem, through=RefundOrderItem)
     created = models.DateTimeField(auto_now_add=True)
     done = models.DateTimeField(null=True)
-    credit_note = models.OneToOneField(CreditNote, null=True, blank=True)
+    credit_note = models.OneToOneField(CreditNote, null=True, blank=True, on_delete=models.CASCADE)
     status = models.CharField(max_length=8, choices=REFUND_STATUS, default='pending')
     reason = models.CharField(max_length=200, blank=True)
     internal_note = models.TextField(

--- a/assopy/templatetags/assopy_tags.py
+++ b/assopy/templatetags/assopy_tags.py
@@ -236,7 +236,7 @@ def user_coupons(user):
             output['invalid'].append(c)
     return output
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def paginate(context, qs, count=20):
     pages = paginator.Paginator(qs, int(count))
     try:
@@ -264,7 +264,7 @@ def render_voucher(context, item):
         'item': item,
     }
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def orderitem_can_be_refunded(context, item):
     req = context['request']
     try:

--- a/assopy/views.py
+++ b/assopy/views.py
@@ -92,7 +92,7 @@ def billing(request, order_id=None):
 
 @render_to_template('assopy/new_account.html')
 def new_account(request):
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         return redirect('assopy-profile')
 
     if request.method == 'GET':
@@ -131,7 +131,7 @@ def new_account_feedback(request):
 @render_to_template('assopy/checkout.html')
 def checkout(request):
     if request.method == 'POST':
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             return http.HttpResponseBadRequest('unauthorized')
         form = aforms.FormTickets(data=request.POST)
         if form.is_valid():

--- a/common/jsonify.py
+++ b/common/jsonify.py
@@ -2,6 +2,8 @@ import datetime
 import json
 import functools
 
+from django.utils.deprecation import CallableBool
+
 
 class MyEncode(json.JSONEncoder):  # pragma: no cover
     def default(self, obj):
@@ -13,9 +15,10 @@ class MyEncode(json.JSONEncoder):  # pragma: no cover
             return obj.strftime('%H:%M')
         elif isinstance(obj, set):
             return list(obj)
-        elif callable(obj):
+        elif isinstance(obj, CallableBool):
             # required to support User.is_authenticated from Django 1.10 onwards
-            return obj()
+            # and avoid depracation warnings
+            return obj == True
 
         return json.JSONEncoder.default(self, obj)
 

--- a/conference/decorators.py
+++ b/conference/decorators.py
@@ -43,7 +43,7 @@ def talk_access(f): # pragma: no cover
     @functools.wraps(f)
     def wrapper(request, slug, **kwargs):
         tlk = get_object_or_404(models.Talk, slug=slug)
-        if request.user.is_anonymous():
+        if request.user.is_anonymous:
             full_access = False
         elif request.user.is_staff:
             full_access = True
@@ -103,7 +103,7 @@ def profile_access(f): # pragma: no cover
                 if not (settings.VOTING_OPENED(conf, request.user) and settings.VOTING_ALLOWED(request.user)):
                     if profile.visibility == 'x':
                         return http.HttpResponseForbidden()
-                    elif profile.visibility == 'm' and request.user.is_anonymous():
+                    elif profile.visibility == 'm' and request.user.is_anonymous:
                         return http.HttpResponseForbidden()
         return f(request, slug, profile=profile, full_access=full_access, **kwargs)
     return wrapper

--- a/conference/forms.py
+++ b/conference/forms.py
@@ -74,7 +74,7 @@ class TagWidget(widgets.TextInput):
         )
     media = property(_media)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ''
         else:
@@ -96,7 +96,7 @@ class TagWidget(widgets.TextInput):
         return mark_safe('<input%s />' % flatatt(final_attrs))
 
 class ReadonlyTagWidget(widgets.TextInput):
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ''
         else:
@@ -145,7 +145,7 @@ class PseudoRadioSelectWidget(forms.widgets.RadioSelect):
     option_template_name = 'conference/widgets/radio_select_option.html'
 
     def get_context(self, name, value, attrs):
-        context = super(PseudoRadioSelect, self).get_context(name, value, attrs)
+        context = super(PseudoRadioSelectWidget, self).get_context(name, value, attrs)
         return context
 
 

--- a/conference/forms.py
+++ b/conference/forms.py
@@ -136,7 +136,7 @@ class MarkEditWidget(forms.Textarea):
         else:
             attrs = dict(attrs)
         attrs['class'] = (attrs.get('class', '') + ' markedit-widget').strip()
-        return super(MarkEditWidget, self).render(name, value, attrs)
+        return super().render(name, value, attrs)
 
 
 
@@ -145,7 +145,7 @@ class PseudoRadioSelectWidget(forms.widgets.RadioSelect):
     option_template_name = 'conference/widgets/radio_select_option.html'
 
     def get_context(self, name, value, attrs):
-        context = super(PseudoRadioSelectWidget, self).get_context(name, value, attrs)
+        context = super().get_context(name, value, attrs)
         return context
 
 
@@ -288,7 +288,7 @@ class SubmissionForm(forms.Form):
             })
         data.update(kwargs.get('initial', {}))
         kwargs['initial'] = data
-        super(SubmissionForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.user = user
 
     #@transaction.atomic
@@ -394,7 +394,7 @@ class TalkForm(forms.ModelForm):
                 data['abstract'] = abstract.body
             data.update(initial)
             kw['initial'] = data
-        super(TalkForm, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
     def save(self, commit=True, speaker=None):
         assert commit, "commit==False not supported yet"
@@ -424,7 +424,7 @@ class TalkForm(forms.ModelForm):
                 level=data['level'],
                 type=data['type']
             )
-        talk = super(TalkForm, self).save(commit=commit)
+        talk = super().save(commit=commit)
         talk.setAbstract(data['abstract'])
 
         if tags:
@@ -455,7 +455,7 @@ class EventForm(forms.ModelForm):
         exclude = ('schedule', 'tracks')
 
     def __init__(self, *args, **kwargs):
-        super(EventForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if self.instance.id:
             self.fields['talk'].queryset = models.Talk.objects\
                 .filter(conference=self.instance.schedule.conference)
@@ -463,7 +463,7 @@ class EventForm(forms.ModelForm):
                 .filter(schedule__conference=self.instance.schedule.conference)
 
     def clean(self):
-        data = super(EventForm, self).clean()
+        data = super().clean()
         if not data['talk'] and not data['custom']:
             raise forms.ValidationError('set the talk or the custom text')
         return data
@@ -485,10 +485,10 @@ class ProfileForm(forms.ModelForm):
            initial = kwargs.get('initial', {})
            initial['bio'] = getattr(i.getBio(), 'body', '')
            kwargs['initial'] = initial
-        super(ProfileForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def save(self, commit=True):
-        profile = super(ProfileForm, self).save(commit)
+        profile = super().save(commit)
         profile.setBio(self.cleaned_data.get('bio', ''))
         return profile
 
@@ -496,7 +496,7 @@ class EventBookingForm(forms.Form):
     value = forms.BooleanField(required=False)
 
     def __init__(self, event, user, *args, **kwargs):
-        super(EventBookingForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.event = event
         self.user = user
 
@@ -519,7 +519,7 @@ class AdminSendMailForm(forms.Form):
 
     def __init__(self, *args, **kw):
         real = kw.pop('real_usage', True)
-        super(AdminSendMailForm, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
         if real:
             self.fields['send_email'].required = True
 

--- a/conference/migrations/0001_initial.py
+++ b/conference/migrations/0001_initial.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 
 
+import django.db.models.deletion
 from django.db import migrations, models
-import conference.models
 from django.conf import settings
+
 import taggit.managers
 import tagging.fields
 import common.django_urls
+
+import conference.models
 
 
 class Migration(migrations.Migration):
@@ -29,7 +32,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='AttendeeProfile',
             fields=[
-                ('user', models.OneToOneField(primary_key=True, serialize=False, to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, primary_key=True, serialize=False, to=settings.AUTH_USER_MODEL)),
                 ('slug', models.SlugField(unique=True)),
                 ('uuid', models.CharField(unique=True, max_length=6)),
                 ('image', models.ImageField(upload_to=conference.models._fs_upload_to(b'profile'), blank=True)),
@@ -74,7 +77,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('object_id', models.IntegerField(verbose_name='Object id', db_index=True)),
                 ('content_type', models.ForeignKey(related_name='conference_conferencetaggeditem_tagged_items', verbose_name='Content type', to='contenttypes.ContentType')),
-                ('tag', models.ForeignKey(related_name='conference_conferencetaggeditem_items', to='conference.ConferenceTag')),
+                ('tag', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='conference_conferencetaggeditem_items', to='conference.ConferenceTag')),
             ],
             options={
                 'verbose_name': 'Tagged Item',
@@ -98,7 +101,7 @@ class Migration(migrations.Migration):
                 ('language', models.CharField(max_length=3)),
                 ('headline', models.CharField(max_length=200)),
                 ('body', models.TextField()),
-                ('deadline', models.ForeignKey(to='conference.Deadline')),
+                ('deadline', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='conference.Deadline')),
             ],
         ),
         migrations.CreateModel(
@@ -129,7 +132,7 @@ class Migration(migrations.Migration):
             name='EventBooking',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('event', models.ForeignKey(to='conference.Event')),
+                ('event', models.ForeignKey(to='conference.Event', on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -137,14 +140,14 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('interest', models.IntegerField()),
-                ('event', models.ForeignKey(to='conference.Event')),
+                ('event', models.ForeignKey(to='conference.Event', on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
             name='EventTrack',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('event', models.ForeignKey(to='conference.Event')),
+                ('event', models.ForeignKey(to='conference.Event', on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -205,7 +208,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('conference', models.CharField(max_length=20)),
                 ('tags', tagging.fields.TagField(max_length=255, blank=True)),
-                ('partner', models.ForeignKey(to='conference.MediaPartner')),
+                ('partner', models.ForeignKey(to='conference.MediaPartner', on_delete=django.db.models.deletion.CASCADE)),
             ],
             options={
                 'ordering': ['conference'],
@@ -219,7 +222,7 @@ class Migration(migrations.Migration):
                 ('language', models.CharField(max_length=3)),
                 ('content', models.CharField(max_length=20)),
                 ('body', models.TextField()),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -228,7 +231,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('conference', models.CharField(max_length=10)),
                 ('timestamp', models.DateTimeField(auto_now_add=True)),
-                ('profile', models.ForeignKey(related_name='presences', to='conference.AttendeeProfile')),
+                ('profile', models.ForeignKey(related_name='presences', to='conference.AttendeeProfile', on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -261,7 +264,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Speaker',
             fields=[
-                ('user', models.OneToOneField(primary_key=True, serialize=False, to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(primary_key=True, serialize=False, to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.CASCADE)),
             ],
             bases=(models.Model, common.django_urls.UrlMixin),
         ),
@@ -306,7 +309,7 @@ class Migration(migrations.Migration):
                 ('conference', models.CharField(max_length=20)),
                 ('income', models.PositiveIntegerField()),
                 ('tags', tagging.fields.TagField(max_length=255, blank=True)),
-                ('sponsor', models.ForeignKey(to='conference.Sponsor')),
+                ('sponsor', models.ForeignKey(to='conference.Sponsor', on_delete=django.db.models.deletion.CASCADE)),
             ],
             options={
                 'ordering': ['conference'],
@@ -348,8 +351,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('helper', models.BooleanField(default=False)),
-                ('speaker', models.ForeignKey(to='conference.Speaker')),
-                ('talk', models.ForeignKey(to='conference.Talk')),
+                ('speaker', models.ForeignKey(to='conference.Speaker', on_delete=django.db.models.deletion.CASCADE)),
+                ('talk', models.ForeignKey(to='conference.Talk', on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -359,8 +362,8 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(help_text='Attendee name, i.e. the person who will attend the conference.', max_length=60, blank=True)),
                 ('frozen', models.BooleanField(default=False, help_text='If a ticket was canceled or otherwise needs to be marked as invalid, please check this checkbox to indicate this.', verbose_name='ticket canceled / invalid / frozen')),
                 ('ticket_type', models.CharField(default=b'standard', max_length=8, choices=[(b'standard', b'standard'), (b'staff', b'staff')])),
-                ('fare', models.ForeignKey(to='conference.Fare')),
-                ('user', models.ForeignKey(help_text='Buyer of the ticket', to=settings.AUTH_USER_MODEL)),
+                ('fare', models.ForeignKey(to='conference.Fare', on_delete=django.db.models.deletion.CASCADE)),
+                ('user', models.ForeignKey(help_text='Buyer of the ticket', to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -373,7 +376,7 @@ class Migration(migrations.Migration):
                 ('order', models.PositiveIntegerField(default=0, verbose_name=b'ordine')),
                 ('translate', models.BooleanField(default=False)),
                 ('outdoor', models.BooleanField(default=False)),
-                ('schedule', models.ForeignKey(to='conference.Schedule')),
+                ('schedule', models.ForeignKey(to='conference.Schedule', on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -381,8 +384,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('vote', models.DecimalField(max_digits=5, decimal_places=2)),
-                ('talk', models.ForeignKey(to='conference.Talk')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('talk', models.ForeignKey(to='conference.Talk', on_delete=django.db.models.deletion.CASCADE)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.CASCADE)),
             ],
             options={
                 'verbose_name': 'Talk voting',
@@ -406,32 +409,32 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='eventtrack',
             name='track',
-            field=models.ForeignKey(to='conference.Track'),
+            field=models.ForeignKey(to='conference.Track', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='eventinterest',
             name='user',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='eventbooking',
             name='user',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='event',
             name='schedule',
-            field=models.ForeignKey(to='conference.Schedule'),
+            field=models.ForeignKey(to='conference.Schedule', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='event',
             name='sponsor',
-            field=models.ForeignKey(blank=True, to='conference.Sponsor', null=True),
+            field=models.ForeignKey(blank=True, to='conference.Sponsor', null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='event',
             name='talk',
-            field=models.ForeignKey(blank=True, to='conference.Talk', null=True),
+            field=models.ForeignKey(blank=True, to='conference.Talk', null=True, on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='event',
@@ -441,12 +444,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='attendeelink',
             name='attendee1',
-            field=models.ForeignKey(related_name='link1', to='conference.AttendeeProfile'),
+            field=models.ForeignKey(related_name='link1', to='conference.AttendeeProfile', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='attendeelink',
             name='attendee2',
-            field=models.ForeignKey(related_name='link2', to='conference.AttendeeProfile'),
+            field=models.ForeignKey(related_name='link2', to='conference.AttendeeProfile', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AlterUniqueTogether(
             name='vototalk',

--- a/conference/templatetags/conference.py
+++ b/conference/templatetags/conference.py
@@ -201,7 +201,7 @@ class TNode(template.Node):
             return v
 
 
-@register.assignment_tag()
+@register.simple_tag()
 def conference_talks(conference=None, status="accepted", tag=None, type=None):
     if conference is None:
         conference = [settings.CONFERENCE]
@@ -663,7 +663,7 @@ def splitbysize(value, arg):
     return grouper(arg, value)
 
 
-@register.assignment_tag()
+@register.simple_tag()
 def conference_sponsor(conference=None, only_tags=None, exclude_tags=None):
     if conference is None:
         conference = settings.CONFERENCE
@@ -830,7 +830,7 @@ def video_cover_url(event, type='front', thumb=False):
     return url
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def embed_video(context, value, args=""):
     """
     {{ talk|embed_video:"source=[youtube, viddler, download, url.to.oembed.endpoint],width=XXX,height=XXX" }}
@@ -1239,7 +1239,7 @@ def next_events(context, time=None):
     return output
 
 
-@register.assignment_tag()
+@register.simple_tag()
 def current_conference():
     return models.Conference.objects.current()
 
@@ -1307,7 +1307,7 @@ def group_tags(tags):
     return sorted(groups.items())
 
 
-@register.assignment_tag()
+@register.simple_tag()
 def talk_data(tid):
     return dataaccess.talk_data(tid)
 
@@ -1319,7 +1319,7 @@ def event_data(eid):
     return event
 
 
-@register.assignment_tag()
+@register.simple_tag()
 def talks_data(tids, conference=None):
     data = dataaccess.talks_data(tids)
     if conference:
@@ -1327,12 +1327,12 @@ def talks_data(tids, conference=None):
     return data
 
 
-@register.assignment_tag()
+@register.simple_tag()
 def schedule_data(sid):
     return dataaccess.schedule_data(sid)
 
 
-@register.assignment_tag()
+@register.simple_tag()
 def schedules_data(sids):
     return dataaccess.schedules_data(sids)
 
@@ -1519,7 +1519,7 @@ def as_datetime(value, format="%Y/%m/%d"):
     return datetime.strptime(value, format)
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def user_votes(context, uid=None, conference=None, talk_id=None):
     if uid is None:
         uid = context['request'].user.id
@@ -1532,7 +1532,7 @@ def user_votes(context, uid=None, conference=None, talk_id=None):
         return votes
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def user_events_interest(context, uid=None, conference=None, event_id=None):
     if uid is None:
         uid = context['request'].user.id

--- a/conference/views.py
+++ b/conference/views.py
@@ -272,7 +272,7 @@ def schedule_event_booking(request, conference, slug, eid):
 @render_to_json
 def schedule_events_booking_status(request, conference):
     data = dataaccess.conference_booking_status(conference)
-    uid = request.user.id if request.user.is_authenticated() else 0
+    uid = request.user.id if request.user.is_authenticated else 0
     for k, v in data.items():
         if uid and uid in v['booked']:
             v['user'] = True

--- a/hcomments/__init__.py
+++ b/hcomments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.apps import AppConfig
 
 

--- a/p3/models.py
+++ b/p3/models.py
@@ -1,14 +1,9 @@
 # -*- coding: utf-8 -*-
 import datetime
-import os
-import os.path
-from collections import defaultdict
 
 from django.conf import settings as dsettings
 from django.core.urlresolvers import reverse
 from django.db import models
-from django.db.models import Q
-from django.db.models.query import QuerySet
 from django.utils.translation import ugettext as _
 from assopy import utils as autils
 
@@ -31,14 +26,15 @@ class P3Talk(models.Model):
     """
     talk = models.OneToOneField('conference.Talk',
                                 related_name='p3_talk',
-                                primary_key=True)
+                                primary_key=True,
+                                on_delete=models.CASCADE)
     sub_community = models.CharField(max_length=20,
                                      choices=TALK_SUBCOMMUNITY,
                                      default='')
 
 
 class SpeakerConference(models.Model):
-    speaker = models.OneToOneField('conference.Speaker', related_name='p3_speaker')
+    speaker = models.OneToOneField('conference.Speaker', related_name='p3_speaker', on_delete=models.CASCADE)
     first_time = models.BooleanField(default=False)
 
 # Configurable t-shirt sizes, diets, experience
@@ -68,7 +64,8 @@ class TicketConferenceQuerySet(models.QuerySet):
 class TicketConference(models.Model):
     ticket = models.OneToOneField(
         Ticket,
-        related_name='p3_conference')
+        related_name='p3_conference',
+        on_delete=models.CASCADE)
     shirt_size = models.CharField(
         max_length=5,
         choices=TICKET_CONFERENCE_SHIRT_SIZES,
@@ -132,7 +129,8 @@ class P3ProfileManager(models.Manager):
 
 
 class P3Profile(models.Model):
-    profile = models.OneToOneField('conference.AttendeeProfile', related_name='p3_profile', primary_key=True)
+    profile = models.OneToOneField(
+        'conference.AttendeeProfile', related_name='p3_profile', primary_key=True, on_delete=models.CASCADE)
     tagline = models.CharField(
         max_length=60, blank=True, help_text=_('describe yourself in one line!'))
     interests = TaggableManager(through=ConferenceTaggedItem)

--- a/p3/templatetags/p3.py
+++ b/p3/templatetags/p3.py
@@ -204,7 +204,7 @@ def render_ticket(context, ticket):
     })
     return ctx
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def fares_available(context, fare_type, sort=None):
     """
     Restituisce l'elenco delle tariffe attive in questo momento per la
@@ -470,19 +470,19 @@ def box_next_events(context):
     })
     return ctx
 
-@register.assignment_tag()
+@register.simple_tag()
 def p3_profile_data(uid):
     return dataaccess.profile_data(uid)
 
-@register.assignment_tag()
+@register.simple_tag()
 def p3_profiles_data(uids):
     return dataaccess.profiles_data(uids)
 
-@register.assignment_tag()
+@register.simple_tag()
 def p3_talk_data(tid):
     return dataaccess.talk_data(tid)
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def get_form(context, name, bound="auto", bound_field=None):
     if '.' in name:
         from conference.utils import dotted_import
@@ -514,7 +514,7 @@ def get_form(context, name, bound="auto", bound_field=None):
         form.is_valid()
     return form
 
-@register.assignment_tag()
+@register.simple_tag()
 def pending_email_change(user):
     try:
         t = amodels.Token.objects.get(ctype='e', user=user)
@@ -522,7 +522,7 @@ def pending_email_change(user):
         return None
     return t.payload
 
-@register.assignment_tag()
+@register.simple_tag()
 def admin_ticketroom_overall_status():
     status = models.TicketRoom.objects.overall_status()
 
@@ -546,7 +546,7 @@ def admin_ticketroom_overall_status():
         'rooms': list(rooms.values()),
     }
 
-@register.assignment_tag()
+@register.simple_tag()
 def warmup_conference_cache(conference=None):
     """
     """
@@ -577,7 +577,7 @@ def frozen_reason(ticket):
         return ''
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def all_user_tickets(context, uid=None, conference=None,
                      status="complete", fare_type="conference"):
     if uid is None:
@@ -595,7 +595,7 @@ def all_user_tickets(context, uid=None, conference=None,
     return tickets
 
 
-@register.assignment_tag()
+@register.simple_tag()
 def p3_tags():
     return dataaccess.tags()
 

--- a/p3/templatetags/sessions.py
+++ b/p3/templatetags/sessions.py
@@ -96,7 +96,7 @@ EXAMPLE_ACCEPTEDSESSIONS = """
 {% endfor %}
 """
 
-@register.assignment_tag
+@register.simple_tag
 def acceptedsessions(conference, filter_types=None, filter_community=None):
 
     talks = models.Talk.objects.filter(
@@ -180,7 +180,7 @@ EXAMPLE_SPEAKERS = """
 <p>{{ speakerdata.count }} speakers in total.</p>
 """
 
-@register.assignment_tag
+@register.simple_tag
 def speakers(conference, filter_types=None):
 
     talks = models.Talk.objects.filter(

--- a/p3/utils.py
+++ b/p3/utils.py
@@ -24,7 +24,7 @@ def group_required(*group_names):
         user has to be member of all listed groups.
     """
     def group_membership_check(user):
-        if not user.is_authenticated():
+        if not user.is_authenticated:
             return False
         if user.is_superuser:
             return True

--- a/p3/views/__init__.py
+++ b/p3/views/__init__.py
@@ -275,7 +275,7 @@ def whos_coming(request, conference=None):
     # profiles can be public or only visible for participants, in the second
     # case only who has a ticket can see them
     access = ('p',)
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         t = dataaccess.all_user_tickets(request.user.id, conference)
         if any(tid for tid, _, _, complete in t if complete):
             access = ('m', 'p')

--- a/p3/views/cart.py
+++ b/p3/views/cart.py
@@ -61,7 +61,7 @@ class P3BillingDataCompany(P3BillingData):
 
 def cart(request):
     u = None
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         try:
             u = request.user.assopy_user
         except AttributeError:
@@ -73,7 +73,7 @@ def cart(request):
     # a valid POST request
     request.session.pop('user-cart', None)
     if request.method == 'POST':
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             return HttpResponseRedirectSeeOther(reverse('p3-cart'))
         form = p3forms.P3FormTickets(data=request.POST, user=u)
         if form.is_valid():

--- a/p3/views/schedule.py
+++ b/p3/views/schedule.py
@@ -136,7 +136,7 @@ def schedule(request, conference):
 
 def schedule_ics(request, conference, mode='conference'):
     if mode == 'my-schedule':
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             raise http.Http404()
         uid = request.user.id
     else:

--- a/pycon/dev-settings.py
+++ b/pycon/dev-settings.py
@@ -34,7 +34,7 @@ INSTALLED_APPS = INSTALLED_APPS + (
 
 #TEST_WITHOUT_MIGRATIONS_COMMAND = 'django_nose.management.commands.test.Command'
 
-MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + (
+MIDDLEWARE = MIDDLEWARE + (
     'django_pdb.middleware.PdbMiddleware',
     # 'devserver.middleware.DevServerMiddleware',
 )

--- a/pycon/middleware.py
+++ b/pycon/middleware.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-class RisingResponse(object):
+from django.utils.deprecation import MiddlewareMixin
+
+
+class RisingResponse(MiddlewareMixin):
     """
     Questo middleware permette ad una vista di chiamare `RisingResponse.stop()`
     per interrompere l'esecuzione corrente.

--- a/pycon/settings.py
+++ b/pycon/settings.py
@@ -241,7 +241,7 @@ TEMPLATES = [{
     },
 }]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -650,7 +650,7 @@ def CONFERENCE_VOTING_ALLOWED(user):
     """ Determine whether user is allowed to participate in talk voting.
 
     """
-    if not user.is_authenticated():
+    if not user.is_authenticated:
         return False
     if user.is_superuser:
         return True
@@ -866,7 +866,7 @@ def CONFERENCE_TALK_VIDEO_ACCESS(request, talk):
     if talk.conference != CONFERENCE_CONFERENCE:
         return True
     u = request.user
-    if u.is_anonymous():
+    if u.is_anonymous:
         return False
     from p3.models import Ticket
 


### PR DESCRIPTION
Branch based off https://github.com/EuroPython/epcon/pull/847 to avoid merge conflicts. 847 should be reviewed/merged first.

before:
```
-- Docs: https://docs.pytest.org/en/latest/warnings.html
============ 129 passed, 35 skipped, 1573 warnings in 29.28 seconds ============
```

after:
```
-- Docs: https://docs.pytest.org/en/latest/warnings.html
============ 129 passed, 35 skipped, 1332 warnings in 27.70 seconds ============
```

Most remaining warnings are generated either by django-cms or are pytest deprecation warnings.