### PR TITLE
Fixes #853

### DIFF
--- a/pycon/urls.py
+++ b/pycon/urls.py
@@ -75,11 +75,11 @@ if settings.DEBUG:
         }),
         url(r'^500/$', defaults.server_error), 
         url(r'^404/$', defaults.page_not_found,
-            kwargs={'exception': Exception("Page not Found!")}),
+            {'exception': Exception("Page not Found!")}),
         url(r'^403/$', defaults.permission_denied, 
-            kwargs={'exception': Exception("Permission Denied")}),
+            {'exception': Exception("Permission Denied")}),
         url(r'^400/$', defaults.bad_request, 
-            kwargs={'exception': Exception("Bad Request!")}),
+            {'exception': Exception("Bad Request!")}),
     ]
 
 urlpatterns += i18n_patterns(

--- a/pycon/urls.py
+++ b/pycon/urls.py
@@ -73,10 +73,13 @@ if settings.DEBUG:
         url(r'^media/(?P<path>.*)$', static.serve, {
             'document_root': settings.MEDIA_ROOT,
         }),
-        url(r'^500/$', defaults.server_error),
-        url(r'^404/$', defaults.page_not_found),
-        url(r'^403/$', defaults.permission_denied),
-        url(r'^400/$', defaults.bad_request),
+        url(r'^500/$', defaults.server_error), 
+        url(r'^404/$', defaults.page_not_found,
+            kwargs={'exception': Exception("Page not Found!")}),
+        url(r'^403/$', defaults.permission_denied, 
+            kwargs={'exception': Exception("Permission Denied")}),
+        url(r'^400/$', defaults.bad_request, 
+            kwargs={'exception': Exception("Bad Request!")}),
     ]
 
 urlpatterns += i18n_patterns(


### PR DESCRIPTION
This is a simple enough PR: just a few lines changes in pycon/urls.py :-)

The issue it aims at fixing (#853) is as follows: it looks like recent versions of Django require an exception to be passed to error pages (i.e., 404 and the like). This PR just adds the required parameter.