### PR TITLE
Allow to login to admin using email.

### DIFF
--- a/assopy/auth_backends.py
+++ b/assopy/auth_backends.py
@@ -40,7 +40,7 @@ class IdBackend(_AssopyBackend):
     backend utilizzato solo internamente per autenticare utenti dato il loro id
     (senza bisogno di password).
     """
-    def authenticate(self, uid=None):
+    def authenticate(self, request, uid=None):
         try:
             user = User.objects.select_related('assopy_user').get(pk=uid, is_active=True)
             auser = user.assopy_user
@@ -57,8 +57,9 @@ class IdBackend(_AssopyBackend):
             return None
 
 class EmailBackend(_AssopyBackend):
-    def authenticate(self, email=None, password=None):
+    def authenticate(self, request, email=None, password=None, username=None):
         try:
+            email = email or username
             user = User.objects.select_related('assopy_user').get(email__iexact=email, is_active=True)
             if user.check_password(password):
                 auser = user.assopy_user


### PR DESCRIPTION
The clean solution would be to create a custom `AdminSite`, override the authentication form and template and register all current `ModelAdmin`s with it; I've tried that locally and the authentication works correctly - however, admin autodiscovery does not work so well - none of the third party admin panels are available.

This PR is an alternative solution - since it passes `username` and `password` to authentication backends, allowing the current `EmailBacked` to accept the email in the `username` field allows the user to authenticate; furthermore, it's still possible to log in using the `username` - unless the `ModelBackend` is removed from authentication backends. 