### PR TITLE
Fix django default login url.

### DIFF
--- a/pycon/urls.py
+++ b/pycon/urls.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.views import defaults, static
+from django.views.generic import RedirectView
 
 from filebrowser.sites import site as fsite
 
@@ -52,7 +53,8 @@ urlpatterns = [
     url(r'^i18n/', include('django.conf.urls.i18n')),
     url(r'^markitup/', include('markitup.urls')),
 
-
+    # TODO umgelurgel: See if the django.auth.urls are used anywhere and if they can be removed
+    url(r'^login/', RedirectView.as_view(pattern_name='accounts:login', permanent=False)),
     url('', include('social.apps.django_app.urls', namespace='social')),
     url('', include('django.contrib.auth.urls', namespace='auth')),
 


### PR DESCRIPTION
Fixing the failure emails:
```
Internal Server Error: /login/

TemplateDoesNotExist at /login/
registration/login.html
```

I'm not sure where do we use the other django.auth urls, we seem to import the reset password views separately in conference/user_panel