### PR TITLE
Add talk voting filters

### DIFF
--- a/conference/management/commands/create_initial_data_for_dev.py
+++ b/conference/management/commands/create_initial_data_for_dev.py
@@ -23,7 +23,7 @@ from conference.models import (
     Speaker,
     ExchangeRate,
 )
-from conference.tests.factories.fare import SponsorIncomeFactory
+from conference.tests.factories.fare import SponsorIncomeFactory, TicketFactory
 from conference.tests.factories.talk import TalkFactory
 from conference.cfp import add_speaker_to_talk
 from conference.accounts import get_or_create_attendee_profile_for_new_user
@@ -78,6 +78,11 @@ class Command(BaseCommand):
             password="europython",
             active=True,
         )
+
+        print("Creating tickets to allow users to vote")
+        # Leaving Cesar out from voting
+        for assopy_user in (admin, alice, bob):
+            TicketFactory(user=assopy_user.user, frozen=False)
 
         print("Making some talk proposals")
         for user in alice, bob, cesar:

--- a/conference/models.py
+++ b/conference/models.py
@@ -809,6 +809,8 @@ class Talk(models.Model, UrlMixin):
         )
 
     def getAbstract(self, language=None):
+        # TODO: this method should always return the contents body
+        #   and the get_abstract method should be retired
         return MultilingualContent.objects.getContent(
             self, "abstracts", language
         )

--- a/conference/models.py
+++ b/conference/models.py
@@ -813,6 +813,15 @@ class Talk(models.Model, UrlMixin):
             self, "abstracts", language
         )
 
+    def get_abstract(self, language=None):
+        abstract = MultilingualContent.objects.getContent(
+            self, "abstracts", language
+        )
+        if abstract:
+            return abstract.body
+        else:
+            return self.abstract_short
+
 
 class TalkSpeaker(models.Model):
     talk = models.ForeignKey(Talk, on_delete=models.CASCADE)

--- a/conference/talk_voting.py
+++ b/conference/talk_voting.py
@@ -4,7 +4,7 @@ from django.db.models import Q, Prefetch
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 
-from conference.models import Conference, Talk, VotoTalk
+from conference.models import Conference, Talk, VotoTalk, TALK_STATUS
 
 
 @login_required
@@ -35,6 +35,7 @@ def talk_voting(request):
     talks = (
         Talk.objects.filter(
             Q(conference=current_conference.code) & ~Q(created_by=request.user)
+            & Q(admin_type='') & Q(status=TALK_STATUS.proposed)
         ).filter(
             *extra_filters
         ).order_by("?")

--- a/conference/talk_voting.py
+++ b/conference/talk_voting.py
@@ -34,8 +34,10 @@ def talk_voting(request):
 
     talks = (
         Talk.objects.filter(
-            Q(conference=current_conference.code) & ~Q(created_by=request.user)
-            & Q(admin_type='') & Q(status=TALK_STATUS.proposed)
+            Q(conference=current_conference.code)
+            & ~Q(created_by=request.user)
+            & Q(admin_type="")
+            & Q(status=TALK_STATUS.proposed)
         ).filter(
             *extra_filters
         ).order_by("?")

--- a/conference/talk_voting.py
+++ b/conference/talk_voting.py
@@ -12,24 +12,26 @@ def talk_voting(request):
     current_conference = Conference.objects.current()
 
     if not current_conference.voting():
-        return TemplateResponse(
-            request, "ep19/bs/talk_voting/voting_is_closed.html"
-        )
+        return TemplateResponse(request, "ep19/bs/talk_voting/voting_is_closed.html")
 
     if not is_user_allowed_to_vote(request.user):
         return TemplateResponse(
-            request, "ep19/bs/talk_voting/voting_is_unavailable.html", {
-                'conference': current_conference,
-            }
+            request,
+            "ep19/bs/talk_voting/voting_is_unavailable.html",
+            {"conference": current_conference},
         )
 
-    filter = request.GET.get('filter')
-    if filter == 'voted':
-        extra_filters = [Q(id__in=VotoTalk.objects.filter(user=request.user).values('talk_id'))]
-    elif filter == 'not-voted':
-        extra_filters = [~Q(id__in=VotoTalk.objects.filter(user=request.user).values('talk_id'))]
+    filter = request.GET.get("filter")
+    if filter == "voted":
+        extra_filters = [
+            Q(id__in=VotoTalk.objects.filter(user=request.user).values("talk_id"))
+        ]
+    elif filter == "not-voted":
+        extra_filters = [
+            ~Q(id__in=VotoTalk.objects.filter(user=request.user).values("talk_id"))
+        ]
     else:
-        filter = 'all'
+        filter = "all"
         extra_filters = []
 
     talks = (
@@ -38,9 +40,9 @@ def talk_voting(request):
             & ~Q(created_by=request.user)
             & Q(admin_type="")
             & Q(status=TALK_STATUS.proposed)
-        ).filter(
-            *extra_filters
-        ).order_by("?")
+        )
+        .filter(*extra_filters)
+        .order_by("?")
         .prefetch_related(
             Prefetch(
                 "vototalk_set",
@@ -88,27 +90,17 @@ def vote_on_a_talk(request, talk_uuid):
                 return TemplateResponse(
                     request,
                     "ep19/bs/talk_voting/_voting_form.html",
-                    {
-                        "talk": talk,
-                        "db_vote": None,
-                        "VotingOptions": VotingOptions,
-                    },
+                    {"talk": talk, "db_vote": None, "VotingOptions": VotingOptions},
                 )
 
-            db_vote = VotoTalk.objects.create(
-                user=request.user, talk=talk, vote=vote
-            )
+            db_vote = VotoTalk.objects.create(user=request.user, talk=talk, vote=vote)
 
         if vote == VotingOptions.no_vote:
             db_vote.delete()
             return TemplateResponse(
                 request,
                 "ep19/bs/talk_voting/_voting_form.html",
-                {
-                    "talk": talk,
-                    "db_vote": None,
-                    "VotingOptions": VotingOptions,
-                },
+                {"talk": talk, "db_vote": None, "VotingOptions": VotingOptions},
             )
 
         db_vote.vote = vote

--- a/templates/ep19/bs/talk_voting/voting.html
+++ b/templates/ep19/bs/talk_voting/voting.html
@@ -1,7 +1,5 @@
 {% extends "ep19/bs/base.html" %}
 
-{% load cms_tags %}
-
 {% block content %}
 <style type="text/css">
 .voting-proposal {

--- a/templates/ep19/bs/talk_voting/voting.html
+++ b/templates/ep19/bs/talk_voting/voting.html
@@ -32,7 +32,7 @@
                 <h4>{{ talk.sub_title }}</h4>
                 <h5>{% for speaker in talk.get_all_speakers %}{{ speaker.user.assopy_user.name }}{% if not forloop.last %}, {% endif %}{% endfor %}</h5>
                 <p>{% for t in talk.tags.all %}<span class='badge badge-secondary'>{{ t }}</span> {% endfor %}</p>
-                <p>{{ talk.abstract_short }}</p>
+                <p>{{ talk.get_abstract }}</p>
                 <p>
                 <code>Type: {{ talk.get_type_display }}; Python level: {{ talk.get_level_display }}; Domain level: {{ talk.get_domain_level_display }}</code>
                 </p>

--- a/templates/ep19/bs/talk_voting/voting.html
+++ b/templates/ep19/bs/talk_voting/voting.html
@@ -1,5 +1,7 @@
 {% extends "ep19/bs/base.html" %}
 
+{% load cms_tags %}
+
 {% block content %}
 <style type="text/css">
 .voting-proposal {
@@ -13,6 +15,11 @@
     <div class="row">
         <div class="col-md-12">
             <h1>Talk Voting</h1>
+            <h4>Filter
+                <a class='btn btn-{% if filter != "all" %}outline-{% endif %}success' href="{% url 'talk_voting:talks' %}?filter=all" >All talks</a>
+                <a class='btn btn-{% if filter != "not-voted" %}outline-{% endif %}success' href="{% url 'talk_voting:talks' %}?filter=not-voted" >Not voted</a>
+                <a class='btn btn-{% if filter != "voted" %}outline-{% endif %}success' href="{% url 'talk_voting:talks' %}?filter=voted" >Voted</a>
+            </h4>
             <p>Below you can see all proposals for EP2019. They are in random order</p>
         </div>
     </div>

--- a/templates/ep19/bs/talk_voting/voting_is_unavailable.html
+++ b/templates/ep19/bs/talk_voting/voting_is_unavailable.html
@@ -7,7 +7,7 @@
     <div class="row">
         <div class="col-md-12">
             <h1>Sorry, you can't vote yet. :(</h1>
-            <p>Only users how have tickets assigned to them either for this conference or one of the previous EuroPythons (since 2015+) can vote on the talks. If you'd like to take part in our current voting that ends on {{ conference.voting_end|date }} you can buy the ticket <a href='{% page_url 'tickets' %}'>here</a>.</p>
+            <p>Only users who have tickets assigned to them either for this conference or one of the previous EuroPythons (since 2015+) can vote on the talks. If you'd like to take part in our current voting that ends on {{ conference.voting_end|date }} you can buy the ticket <a href='{% page_url 'tickets' %}'>here</a>.</p>
         </div>
     </div>
 </div>

--- a/tests/test_new_talk_voting.py
+++ b/tests/test_new_talk_voting.py
@@ -1,0 +1,38 @@
+import pytest
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.mark.xfail
+def test_talk_voting_unavailable_if_not_enabled():
+    assert True == False
+
+
+@pytest.mark.xfail
+def test_talk_voting_unavailable_without_a_ticket():
+    assert True == False
+
+
+@pytest.mark.xfail
+def test_talk_voting_available_with_ticket_and_enabled():
+    assert True == False
+
+
+@pytest.mark.xfail
+def test_talk_voting_filters():
+    assert True == False
+
+
+@pytest.mark.xfail
+def test_talk_voting_hides_admin_talks():
+    assert True == False
+
+
+@pytest.mark.xfail
+def test_talk_voting_hides_approved_talks():
+    assert True == False
+
+
+@pytest.mark.xfail
+def test_talk_voting_creates_new_vote():
+    assert True == False


### PR DESCRIPTION
Fixes #951 

Adds filters removing admin talks, approved talks (always enabled), and allows users to filter talks displayed in the talk voting page. Also shows full abstract for the talks in the talk voting page.

![image](https://user-images.githubusercontent.com/3726919/57638090-50637c80-75ad-11e9-834d-c233eacbde04.png)

![image](https://user-images.githubusercontent.com/3726919/57638105-5a857b00-75ad-11e9-8938-24ea1abb183f.png)

![image](https://user-images.githubusercontent.com/3726919/57638128-65401000-75ad-11e9-838a-802048d63f0e.png)
