### PR TITLE
Fix the doppelganger url from admin.

### DIFF
--- a/assopy/admin.py
+++ b/assopy/admin.py
@@ -419,7 +419,7 @@ class AuthUserAdmin(UserAdmin):
         auth.login(request, user)
         request.session['doppelganger'] = udata
 
-        return http.HttpResponseRedirect(urlresolvers.reverse('assopy-tickets'))
+        return http.HttpResponseRedirect(urlresolvers.reverse('user_panel:dashboard'))
 
     def kill_doppelganger(self, request):
         uid = request.session.pop('doppelganger')[0]


### PR DESCRIPTION
This fixes the issue behind the failure emails we've been seeing about `/accounts/tickets` being inaccessible.