### PR TITLE
WIP Add sold conference ticket count to admin conference stats.

### DIFF
--- a/conference/admin.py
+++ b/conference/admin.py
@@ -156,7 +156,6 @@ class ConferenceAdmin(admin.ModelAdmin):
                 return s
 
     def stats_list(self, request, cid):
-        stats = []
         stats = self.available_stats(cid)
 
         return TemplateResponse(

--- a/p3/stats.py
+++ b/p3/stats.py
@@ -1,12 +1,14 @@
-
 from collections import defaultdict
-from conference.models import Ticket, Speaker, Talk
+
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.db.models import Q, Count
+
 from p3 import models
 from conference import models as cmodels
+from conference.models import Ticket, Speaker, Talk
+from conference.tickets import count_number_of_sold_training_tickets_including_combined_tickets
 
 
 def _create_option(id, title, total_qs, **kwargs):
@@ -345,6 +347,11 @@ def ticket_status_for_voupe03_tickets(code, voupe03):
 def ticket_status_no_code(conf, multiple_assignments, orphan_tickets, spam_recruiting, voupe03):
     return [
         _create_option('ticket_sold', 'Sold tickets', _tickets(conf, 'conference')),
+        {
+            'id': 'training_tickets_sold',
+            'title': 'Sold training tickets (including combined)',
+            'total': count_number_of_sold_training_tickets_including_combined_tickets(),
+        },
         _create_option('assigned_tickets', 'Assigned tickets', _assigned_tickets(conf)),
         _create_option('unassigned_tickets', 'Unassigned tickets', _unassigned_tickets(conf)),
         # _create_option('sim_tickets', 'Tickets with SIM card orders', sim_tickets),  # FIXME: remove hotels and sim

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -5,6 +5,7 @@ from pytest import mark, raises
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.contrib.messages import constants as messages_constants
+from django.utils import timezone
 
 from assopy.models import Order
 from assopy.models import Vat
@@ -91,8 +92,8 @@ def test_can_buy_tickets_if_fare_is_available(db, user_client):
     _setup()
     set_early_bird_fare_dates(
         settings.CONFERENCE_CONFERENCE,
-        date.today(),
-        date.today() + timedelta(days=1),
+        timezone.now().date(),
+        timezone.now().date() + timedelta(days=1),
     )
     second_step_company = reverse("cart:step2_pick_tickets", args=["company"])
 
@@ -113,8 +114,8 @@ def test_can_buy_training_tickets(db, user_client):
     _setup()
     set_regular_fare_dates(
         settings.CONFERENCE_CONFERENCE,
-        date.today(),
-        date.today() + timedelta(days=1),
+        timezone.now().date(),
+        timezone.now().date() + timedelta(days=1),
     )
     second_step_company = reverse("cart:step2_pick_tickets", args=["company"])
 
@@ -135,8 +136,8 @@ def test_can_buy_combined_tickets(db, user_client):
     _setup()
     set_regular_fare_dates(
         settings.CONFERENCE_CONFERENCE,
-        date.today(),
-        date.today() + timedelta(days=1),
+        timezone.now().date(),
+        timezone.now().date() + timedelta(days=1),
     )
     second_step_company = reverse("cart:step2_pick_tickets", args=["company"])
 
@@ -157,8 +158,8 @@ def test_can_apply_personal_ticket_coupon(db, user_client):
     _setup()
     set_early_bird_fare_dates(
         settings.CONFERENCE_CONFERENCE,
-        date.today(),
-        date.today() + timedelta(days=1),
+        timezone.now().date(),
+        timezone.now().date() + timedelta(days=1),
     )
     second_step_company = reverse("cart:step2_pick_tickets", args=["company"])
     coupon = CouponFactory(user=user_client.user.assopy_user)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3726919/58029563-25cd7280-7b1d-11e9-8ff0-788f7db8e36a.png)

Adding it there as that page seems to be used by the admin staff. marking this as WIP as we'll need to address the `assigned_ticket` stat, too.