### PR TITLE
Link back to speaker profile from talk page

### DIFF
--- a/conference/talks.py
+++ b/conference/talks.py
@@ -60,6 +60,7 @@ def dump_relevant_talk_information_to_dict(talk: Talk):
                 "company_homepage": ap.company_homepage,
                 "bio": getattr(ap.getBio(), "body", ""),
                 "phone": ap.phone,
+                "slug": ap.slug,
             }
         )
 

--- a/templates/ep19/bs/talks/talk.html
+++ b/templates/ep19/bs/talks/talk.html
@@ -19,7 +19,7 @@
 
 <div class="container page" id="talk_page">
     <nav aria-label="breadcrumb">
-        <ol class="breadcrumb">
+        <ol class="breadcrumb">{# TODO: replace hardcoded paths by generated ones! #}
             <li class="breadcrumb-item"><a href="/">Home</a></li>
             <li class="breadcrumb-item"><a href="/events/sessions/#Talks">Talks</a></li>
             <li class="breadcrumb-item active">{{ talk_as_dict.title }}<li>
@@ -32,7 +32,7 @@
                 <h1>{{ talk.title }}</h1>
                 <h3>{{ talk.sub_title }}</h3>
                 <h5>{% for speaker in talk_as_dict.speakers %}
-                    {{ speaker.name }}{% if not forloop.last %}, {% endif %}
+                    <a href="{% url 'profiles:profile' profile_slug=speaker.slug %}">{{ speaker.name }}</a>{% if not forloop.last %}, {% endif %}
                     {% endfor %}
                 </h5>
                 <p>

--- a/templates/ep19/bs/talks/talk.html
+++ b/templates/ep19/bs/talks/talk.html
@@ -20,15 +20,15 @@
 <div class="container page" id="talk_page">
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
-            <li class='breadcrumb-item'><a href="/">Home</a></li>
-            <li class='breadcrumb-item'><a href='#'>Talks</a></li>
-            <li class='breadcrumb-item active'>{{ talk_as_dict.title }}<li>
+            <li class="breadcrumb-item"><a href="/">Home</a></li>
+            <li class="breadcrumb-item"><a href="/events/sessions/#Talks">Talks</a></li>
+            <li class="breadcrumb-item active">{{ talk_as_dict.title }}<li>
         </ol>
     </nav>
 
     <div class="row">
         <div class="col-md-12">
-            <div class='talk'>
+            <div class="talk">
                 <h1>{{ talk.title }}</h1>
                 <h3>{{ talk.sub_title }}</h3>
                 <h5>{% for speaker in talk_as_dict.speakers %}
@@ -37,7 +37,7 @@
                 </h5>
                 <p>
                     {% for tag in talk_as_dict.tags %}
-                    <span class='badge badge-secondary'>{{ tag }}</span>
+                    <span class="badge badge-secondary">{{ tag }}</span>
                     {% endfor %}
                 </p>
                 <p>{{ talk_as_dict.abstract|linebreaks }}</p>
@@ -47,11 +47,11 @@
             </div>
 
 
-            <div class='speakers'>
+            <div class="speakers">
             {% for speaker in talk_as_dict.speakers %}
-            <div class='speaker'>
+            <div class="speaker">
             <h3>{{ speaker.name }}</h3>
-            <h4><a href='{{ speaker.company_homepage }}' target="_blank">{{ speaker.company }}</a></h4>
+            <h4><a href="{{ speaker.company_homepage }}" target="_blank">{{ speaker.company }}</a></h4>
             <p>
             {{ speaker.bio|linebreaks }}
             </p>


### PR DESCRIPTION
Currently, on the detail page of a EuroPython 2019 talk there's a link to the speaker's company page (\*sic\*) but no (easy) way to see the speaker's profile. ([example](https://ep2019.europython.eu/talks/2bwgnvQ-modern-continuous-delivery-for-python-developers/))

This PR turns the speaker name(s) into links that help readers to find out more about the speaker(s), quickly.

Includes a few markup fixes of the affected template, in a separate commit.