### PR TITLE
Add ability to regenerate invoices.

### DIFF
--- a/templates/admin/assopy/invoice/change_form.html
+++ b/templates/admin/assopy/invoice/change_form.html
@@ -1,0 +1,17 @@
+{% extends "admin/change_form.html" %}
+{% block object-tools %}
+    <ul class="object-tools">
+        <li>
+            <a class="historylink" href="history/">History</a>
+        </li>
+        <li>
+            <a class="" href="{% url 'admin:assopy-invoice-regenerate' invoice_id=original.id %}">Regenerate invoice</a>
+        </li>
+        <li>
+            <a class="" href="{% url 'admin:assopy-invoice-preview' invoice_id=original.id %}">Preview</a>
+        </li>
+        <li>
+            <a class="" href="{% url 'admin:assopy-invoice-associated-order' invoice_id=original.id %}">Order</a>
+        </li>
+    </ul>
+{% endblock %}

--- a/templates/admin/assopy/order/change_form.html
+++ b/templates/admin/assopy/order/change_form.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_form.html" %}
+{% block object-tools %}
+    <ul class="object-tools">
+        <li>
+            <a class="historylink" href="history/">History</a>
+        </li>
+        <li>
+            <a class="" href="{% url 'admin:assopy-order-latest-invoice' order_id=original.id %}">Latest invoice</a>
+        </li>
+    </ul>
+{% endblock %}


### PR DESCRIPTION
This adds a button that regenerates an invoice and a button that takes you to the invoice preview to the admin invoice detail page:

![image](https://user-images.githubusercontent.com/3726919/58579460-66c73480-824b-11e9-80b4-9470f18ca612.png)

A few gotchas - after the invoice is created, the invoice generation uses the contents of `Invoice.customer` when generating the html - so any changes made to the order (e.g. updating the vat number or billing notes) won't appear on the invoice. I can change that - but then updating an Order will overwrite any changes that could have been made to `Invoice.customer`. @malemburg / @sm6xmm - let me know what behaviour would be most useful for you.