### PR TITLE
Hiding the FAQ entry in the footer.

### DIFF
--- a/templates/ep19/bs/footer/_show_menu_in_footer.html
+++ b/templates/ep19/bs/footer/_show_menu_in_footer.html
@@ -2,7 +2,7 @@
 
 {% for child in children %}
 {% if not child.parent %}
-<div class='col-md-2'>
+<div id="footer-menu-{{ child.get_menu_title|lower }}" class="col-md-2">
     <h4>{{ child.get_menu_title }}</h4>
 {% else %}
     <li class="cms_menu_child">
@@ -18,3 +18,9 @@
 </div>
 {% endif %}
 {% endfor %}
+
+<style>
+    #footer-menu-faq {
+        display: none
+    }
+</style>


### PR DESCRIPTION
I didn't see a way to hide items based on their Page configuration - (as in, it either appears in all menus or in none), so using css to avoid showing the entry.