### PR TITLE
Styling fixes - NAV and schedule width

### DIFF
--- a/assets/css/ep2019-customisations.css
+++ b/assets/css/ep2019-customisations.css
@@ -108,6 +108,22 @@ a.navbar-brand:hover{
     margin-top: 12px;
 }
 
+/* Display nav menu on hover */
+.dropdown:hover>.dropdown-menu {
+  display: block;
+}
+
+/* Fully expand NAV when using the hamburger menu */
+@media only screen and (max-width: 992px) {
+    .dropdown>.dropdown-menu {
+        display: block;
+    }
+
+    a.nav-link {
+        color: #ffffff;
+    }
+}
+
 /* Highlight selected dropdown item */
 .dropdown-item:hover, .dropdown-item:focus {
     text-decoration: none;

--- a/templates/ep19/bs/header/_nav_menu.html
+++ b/templates/ep19/bs/header/_nav_menu.html
@@ -4,7 +4,7 @@
 <li class="nav-item {% if child.children %} dropdown {% endif %}">
 	<a class="nav-link {% if child.children %} dropdown-toggle {% endif %}"
 	   {% if child.children %}
-	   href="#"
+	   href="{{ child.attr.redirect_url|default:child.get_absolute_url }}"
 	   role="button"
 	   data-toggle="dropdown"
 	   aria-haspopup="true"
@@ -18,11 +18,6 @@
 	{% if child.children %}
 	<div class="dropdown-menu"
 		 aria-labelledby="navbarDropdown">
-		<a class="dropdown-item"
-			href="{{ child.attr.redirect_url|default:child.get_absolute_url }}">
-			{{ child.get_menu_title }}
-		</a>
-		<div class="dropdown-divider"></div>
 		{% for subchild in child.children %}
 			<a class="dropdown-item"
 			   href="{{ subchild.attr.redirect_url|default:subchild.get_absolute_url }}">

--- a/templates/ep19/bs/schedule/schedule.html
+++ b/templates/ep19/bs/schedule/schedule.html
@@ -7,7 +7,7 @@
 
 <style>
 .schedule {
-    width: 100vw;
+    width: calc(100vw - (100vw - 100%));
     overflow-x: auto;
 }
 


### PR DESCRIPTION
Fixes #939 
Fixes #942 

Adds NAV dropdown on hover. On mobile, when opening the hamburger menu, the child menus are expanded:

![image](https://user-images.githubusercontent.com/3726919/60115921-4a011c80-9777-11e9-9e60-62dc147fa384.png)

Also fixes an issue with the schedule being wider than the rest of the page (before):

![image](https://user-images.githubusercontent.com/3726919/60116006-82a0f600-9777-11e9-99cf-57a0594988e5.png)
