### PR TITLE
Add Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.6-stretch
+RUN mkdir /epcon
+RUN apt-get update
+RUN apt-get install -y dialog
+RUN apt-get install -y whiptail
+RUN apt-get install -y apt-utils
+RUN apt-get upgrade -y
+RUN apt-get install -y virtualenv
+WORKDIR /epcon
+COPY . /epcon/
+RUN ./provision.sh
+# The command above created a venv in /epcon-env
+# We can activate it by setting some shell envs
+ENV VIRTUAL_ENV=/epcon-env
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3.6'
+
+services:
+  web:
+    build: .
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/code
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
This PR adds a Dockerfile and bare-bones docker compose for epson. Especially useful for Mac users. The resulting Django app will start with a sqlite db and listens on port 8000. On your local machine, open http://localhost:8000/

Usage: docker-compose build && docker-compose up

Closes #1074