### PR TITLE
Use the already created countries when creating Order.

### DIFF
--- a/conference/management/commands/create_initial_data_for_dev.py
+++ b/conference/management/commands/create_initial_data_for_dev.py
@@ -196,6 +196,7 @@ class Command(BaseCommand):
             new_page(rev_id, title, parent=about_europython_page)
 
         print("Creating some countries")
+        created_countries = []
         for iso, name in [
             ("PL", "Poland"),
             ("DE", "Germany"),
@@ -204,7 +205,8 @@ class Command(BaseCommand):
             ("IT", "Italy"),
             ("CH", "Switzerland"),
         ]:
-            Country.objects.get_or_create(iso=iso, name=name)
+            country, _created = Country.objects.get_or_create(iso=iso, name=name)
+            created_countries.append(country)
 
         print("Creating sponsors")
         SponsorIncomeFactory(
@@ -243,6 +245,7 @@ class Command(BaseCommand):
             order = OrderFactory(
                 user=assopy_user,
                 items=[(fare, {"qty": 1}), ],
+                country=random.choice(created_countries),
             )
             order._complete = True
             order.save()


### PR DESCRIPTION
OrderFactory includes a CountryFactory, so sometimes it would try to cause a unique constraint
violation. This patch explicitly passes a country to the OrderFactory in create_initial_data_for_dev
to avoid this issue.

fixes: #1078