### PR TITLE
docker-compose update to enable pdb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3.7'
 
 services:
   epcon:
+    stdin_open: true
+    tty: true
     build:
       context: .
     environment:


### PR DESCRIPTION
* Currently django-pdb doesn't work well with Docker.
  Adding those 2 parameters enables one to put a breakpoint in the code
  and run `docker attach <containerid>` to attach to a pdb session.
  source: https://stackoverflow.com/a/40449862