### PR TITLE
Fix for database name

### DIFF
--- a/pycon/settings.py
+++ b/pycon/settings.py
@@ -65,7 +65,7 @@ SITE_DATA_ROOT = DATA_DIR + "/site"
 # --------
 DATABASES = {
     'default': dj_database_url.config(
-        default='sqlite:///{}/epcon_staging.db'.format(SITE_DATA_ROOT)
+        default='sqlite:///{}/epcon.db'.format(SITE_DATA_ROOT)
     ),
 }
 


### PR DESCRIPTION
* Database used in the settings was called 'epcon_staging.db' and the
  database that 'make drop-db' was trying to delete was called
  'epcon.db'. Thus, no DB was being dropped.
  This fix renames the 'epcon_staging.db' to 'epcon.db'.