### PR TITLE
Show Manage ticket links in order summary (#1095)

### DIFF
--- a/templates/ep19/bs/cart/_order_summary.html
+++ b/templates/ep19/bs/cart/_order_summary.html
@@ -4,14 +4,20 @@
     <tr>
         <th>code</th>
         <th>ticket</th>
-        <th class='text-right'>&euro;</th>
+        <th>&euro;</th>
+        <th class='text-right'>Manage</th>
     </tr>
 
     {% for item in order.orderitem_set.all %}
     <tr>
         <td>{{ item.code }}</td>
         <td>{% if item.ticket %}{{ item.ticket }}{% else %}{{ item.description }}{% endif %}</td>
-        <td class='text-right'>{{ item.price }}</td>
+        <td>{{ item.price }}</td>
+        <td class='text-right'>
+            <a class='btn btn-outline-primary' href='{% url "user_panel:manage_ticket" item.ticket.id %}'>Configure ticket</a>
+            <a class='btn btn-outline-primary' href='{% url "user_panel:assign_ticket" item.ticket.id %}'>Assign ticket</a>
+        </td>
+
     </tr>
     {% endfor %}
 </table>

--- a/templates/ep19/bs/cart/step_5_congrats_order_complete.html
+++ b/templates/ep19/bs/cart/step_5_congrats_order_complete.html
@@ -13,10 +13,6 @@
             <h1>Congrats! Order #{{ order.code }} complete.</h1>
 
             {% include "ep19/bs/cart/_order_summary.html" %}
-
-            <p style='margin-top: 5em'>
-            You can now manage your tickets in your <a href='{% url "user_panel:dashboard" %}'>user panel</a>.
-            </p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
While the #1095 mentions that we should directly display the form to assign the tickets, I've decided to display the management buttons for now (after discussing with @umgelurgel ).
I think it looks nicer especially for a bigger order and it doesn't force user to go through additional steps (forms) after purchasing the tickets.

![EuroPython_2019_·_Basel__Switzerland__8-14_July_2019](https://user-images.githubusercontent.com/4835412/70743896-f84a4f80-1d20-11ea-83bb-5c5191ceb34e.png)
