### PR TITLE
ticket change: add link to Order and Invoice

### DIFF
--- a/templates/admin/conference/ticket/change_form.html
+++ b/templates/admin/conference/ticket/change_form.html
@@ -1,0 +1,14 @@
+{% extends "admin/change_form.html" %}
+{% block object-tools %}
+    <ul class="object-tools">
+        <li>
+            <a class="historylink" href="history/">History</a>
+        </li>
+        <li>
+            <a class="" href="{% url 'admin:assopy_order_change' original.orderitem.order_id %}">Order</a>
+        </li>
+        <li>
+            <a class="" href="{% url 'admin:assopy-order-latest-invoice' original.orderitem.order_id %}">Latest invoice</a>
+        </li>
+    </ul>
+{% endblock %}


### PR DESCRIPTION
With this change it's no longer possible to access the first 3 orders generated by `create_initial_data_for_dev` because those orders don't have invoices.

Should I create `InvoiceFactory` or is there a better way to attach an invoice to demo data?
Also, I'm assuming that *every* ticket will have an invoice attached to it (based on what I see in the code) - is this correct? Or should I take into account that there might be tickets without invoices?

cc @umgelurgel 