### PR TITLE
Add setup for VS Code debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach",
+            "type": "python",
+            "request": "attach",
+            "port": 3000,
+            "host": "localhost",
+            "django": true, // allows you to set breakpoints in Django template files.
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "." // automatically maps to the remote cwd where your app is running
+                }
+            ],
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ $ docker-compose up
 
 You can access the admin pages using the `admin` username. You can login to the public pages using either `alice@europython.eu` or `bob@europython.eu`. All users' passwords are `europython`.
 
+## Debugging with VS Code
+
+To start a server with the VS Code debugger enabled, run:
+
+```bash
+$ docker -f docker-compose.yml -f docker-compose-vscode-debugger.yml up
+```
+
+Next, run "Start Debugging" command in VS Code (otherwise, the `docker-compose up`
+command will be *stuck* waiting for the debugger to attach).
+Now you can put breakpoints in your code (even in the Django template files).
+
 ## Testing
 
 ```bash

--- a/docker-compose-vscode-debugger.yml
+++ b/docker-compose-vscode-debugger.yml
@@ -1,0 +1,7 @@
+version: '3.7'
+
+services:
+  epcon:
+    command: ["python -m ptvsd --host 0.0.0.0 --port 3000 --wait ./manage.py runserver --noreload --nothreading 0.0.0.0:8888"]
+    ports:
+      - "3000:3000"

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -14,5 +14,6 @@ black
 
 django-pdb
 pdbpp
+ptvsd
 
 pip-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@
 #
 apipkg==1.5               # via execnet
 appdirs==1.4.3            # via black
+appnope==0.1.0            # via ipython
 attrs==19.3.0             # via black, pytest
 babel==2.8.0              # via django-phonenumber-field
 backcall==0.1.0           # via ipython
@@ -84,6 +85,8 @@ pillow==7.0.0             # via cairosvg, djangocms-text-ckeditor, easy-thumbnai
 pip-tools==4.3.0
 pluggy==0.13.1            # via pytest
 prompt-toolkit==3.0.2     # via ipython
+polib==1.1.0              # via django-rosetta
+ptvsd==4.3.2
 ptyprocess==0.6.0         # via pexpect
 py==1.8.1                 # via pytest
 pyasn1==0.4.8             # via python-jose, rsa


### PR DESCRIPTION
I'm not sure if someone else will find it useful, but this PR adds a command to docker-compose that will enable VS Code debugger for Django in Docker. That way, one can easily put breakpoints in places like Django template files (I've spent way too much time trying to figure out what variables are available in the template).

Feel free to close it if you find it too invasive for non-vs-code users.