### PR TITLE
Upgrade the base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,20 @@
 # Base image
-FROM python:3.6-buster
+FROM python:3.6
+
+# Update system
+RUN apt-get update && apt-get -y upgrade && apt-get -y autoremove
 
 # Install system dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-                    build-essential \
-                    locales \
-                    libssl-dev \
-                    libxrender-dev \
-                    libxml2-dev \
-                    libxslt1-dev \
-                    sqlite3 \
-                    wget \
-                    curl \
-                    git
-
-RUN pip install pip --upgrade
+RUN apt-get install -y build-essential sqlite3
 
 # Create main code folder
 RUN mkdir /code
 WORKDIR /code
 
-# Install dev dependencies
+# Install dev dependencies (simulates `make install`)
 COPY ./requirements-dev.txt requirements-dev.txt
-RUN pip install -r requirements-dev.txt
+RUN pip install -U pip
+RUN pip install -U pip-tools
+RUN pip-sync requirements-dev.txt
 
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM python:3.6-stretch
+FROM python:3.6-buster
 
 # Install system dependencies
 RUN apt-get update && \
@@ -10,6 +10,7 @@ RUN apt-get update && \
                     libxrender-dev \
                     libxml2-dev \
                     libxslt1-dev \
+                    sqlite3 \
                     wget \
                     curl \
                     git


### PR DESCRIPTION
Benefits:
* has an updated libcairo2 (v1.16.0) so WeazyPrint won't complain any more
* has an updated SQLite (v3.27.2) 
* security and reliability updates