### PR TITLE
Fix order summary not showing on prod website.

### DIFF
--- a/templates/conference/cart/_order_summary.html
+++ b/templates/conference/cart/_order_summary.html
@@ -20,7 +20,7 @@
         {% endif %}
         <td>{{ item.code }}</td>
         <td>{% if item.ticket %}{{ item.ticket }}{% else %}{{ item.description }}{% endif %}</td>
-        {% if order.is_complete %}
+        {% if order.is_complete and item.ticket %}
             <td>{{ item.price }}</td>
             <td class='text-right'>
                 <a class='btn btn-outline-primary' href='{% url "user_panel:manage_ticket" item.ticket.id %}'>Configure ticket</a>


### PR DESCRIPTION
Turns out this was caused by bug in the template due to an order
item not having item.ticket (the discount coupon entry).

Fixes #1262.