### PR TITLE
Disable t-shirt and diet configuration on tickets.

### DIFF
--- a/conference/user_panel.py
+++ b/conference/user_panel.py
@@ -213,7 +213,12 @@ class TicketConferenceConfigForm(forms.ModelForm):
 
     class Meta:
         model = TicketConference
-        fields = ["name", "diet", "shirt_size", "tagline", "days"]
+        fields = ["name", 
+                  # XXX Disabled for EP2020; see #1269
+                  #"diet", 
+                  #"shirt_size", 
+                  "tagline", 
+                  "days"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/templates/conference/user_panel/configure_ticket.html
+++ b/templates/conference/user_panel/configure_ticket.html
@@ -22,6 +22,7 @@
             <input type="submit" class="btn btn-primary" value="Save">
         </form>
     </div>
+{% comment "XXX Disabled for EP2020, see #1269" %}
     <div class="col-md-4 mt-4">
       <h3>Shirt size guide</h3>
       <h6>All sizes shown are in centimeters</h6>
@@ -30,5 +31,6 @@
       <h4 class="mt-4">Straight cut</h4>
       <img src="{% static 'img/straight-cut-size-guide.png' %}" class="img-fluid" alt="Straight cut size guide">
     </div>
+{% endcomment %}
 </div>
 {% endblock %}

--- a/tests/test_new_talk_voting.py
+++ b/tests/test_new_talk_voting.py
@@ -14,7 +14,7 @@ pytestmark = [pytest.mark.django_db]
 
 
 def test_talk_voting_unavailable_before_talk_voting_start(user_client):
-    get_default_conference(voting_start=timezone.now() + timedelta(days=1))
+    get_default_conference(voting_start=timezone.now() + timedelta(days=2))
     url = reverse('talk_voting:talks')
 
     response = user_client.get(url)
@@ -24,7 +24,7 @@ def test_talk_voting_unavailable_before_talk_voting_start(user_client):
 
 
 def test_talk_voting_unavailable_after_talk_voting_end(user_client):
-    get_default_conference(voting_end=timezone.now() - timedelta(days=1))
+    get_default_conference(voting_end=timezone.now() - timedelta(days=2))
     url = reverse('talk_voting:talks')
 
     response = user_client.get(url)

--- a/tests/test_user_panel.py
+++ b/tests/test_user_panel.py
@@ -144,8 +144,9 @@ def test_user_panel_update_ticket(client):
     response = client.post(
         reverse("user_panel:manage_ticket", kwargs={"ticket_id": ticket1.id}),
         {
-            "diet": "other",
-            "shirt_size": "xxxl",
+            # XXX Disabled for EP2020, see #1269
+            #"diet": "other",
+            #"shirt_size": "xxxl",
             "tagline": "xyz",
             "days": "2019-07-10",
         },
@@ -155,8 +156,9 @@ def test_user_panel_update_ticket(client):
     ticket1.refresh_from_db()
     ticketconference.refresh_from_db()
     assert ticket1.name == ticketconference.name
-    assert ticketconference.diet == "other"
-    assert ticketconference.shirt_size == "xxxl"
+    # XXX Disabled for EP2020, see #1269
+    #assert ticketconference.diet == "other"
+    #assert ticketconference.shirt_size == "xxxl"
     assert ticketconference.tagline == "xyz"
     assert ticketconference.days == "2019-07-10"
 
@@ -184,7 +186,7 @@ def test_user_panel_update_ticket_cannot_update_name(client):
             "name": new_name
         },
     )
-    assert response.status_code == 200
+    assert response.status_code in (200, 302)
 
     ticket1.refresh_from_db()
     ticketconference.refresh_from_db()


### PR DESCRIPTION
This is only needed for EP2020 Online.

Fixes #1269