### PR TITLE
Enhance the schedule display

### DIFF
--- a/conference/dataaccess.py
+++ b/conference/dataaccess.py
@@ -109,6 +109,7 @@ def talk_data(tid, preload=None):
         speakers.append({
             'id': r['speaker'],
             'name': profile['name'],
+            'company': profile['company'],
             'slug': profile['slug'],
             'helper': r['helper'],
         })

--- a/conference/schedule.py
+++ b/conference/schedule.py
@@ -178,7 +178,10 @@ def schedule(request, day=None, month=None):
                 level=talk_meta.get("level", None),
                 speakers=talk_meta.get("speakers", []),
                 can_be_starred=talk_meta.get("id", 0) > 0,
+                admin_type=talk_meta.get('admin_type', ''),
             )
+            if _debug:
+                print ('talk_meta = %r' % talk_meta)
 
             talks.append(t)
 
@@ -227,6 +230,7 @@ class Talk:
     slug: typing.Optional[str]
     language: typing.Optional[str]
     level: typing.Optional[str]
+    admin_type: typing.Optional[str]
     speakers: typing.List[str]
     can_be_starred: bool
     start_column: int

--- a/templates/conference/schedule/schedule.html
+++ b/templates/conference/schedule/schedule.html
@@ -1,5 +1,6 @@
 {% extends "conference/base.html" %}
 {% load conference assopy_tags i18n %}
+{% load tz %}
 
 {% block body %}
 
@@ -19,9 +20,6 @@
     width: calc((100vw + 20px) * 7);
 }
 .schedule__time {
-    position: sticky;
-    top: 0;
-    left: 0;
     background: white;
 }
 .schedule__talk {
@@ -65,16 +63,10 @@
     width: 100%;
     position: relative;
 }
-.schedule__day > :first-child {
-    position: sticky;
-    left: 0;
-    z-index: 30;
-    background: white;
-}
 .schedule__grid {
     --cols: 1;
     --rows: 1;
-    --height: 25px;
+    --height: 22px;
     --min-width: calc(100vw - 60px);
     display: grid;
     grid-template-columns: repeat(var(--cols), minmax(var(--min-width), 1fr));
@@ -92,29 +84,36 @@
     background: #d4d2cd;
 }
 .schedule__day--sidebar {
+    position: sticky;
+    top: 0;
+    left: 0;
+    z-index: 10;
     grid-template-columns: 50px;
     margin-right: 5px;
-}
-.schedule__day--sidebar {
     font-weight: bold;
     font-size: 14px;
     text-align: center;
+}
+.schedule__day--time {
+    grid-template-columns: 50px;
+    margin-right: 5px;
 }
 .schedule__grid > div {
     {% comment %} border: 1px solid red; {% endcomment %}
 }
 .schedule__day__talk_title {
     font-weight: bold;
-    font-size: 12px;
+    font-size: 0.8em;
     line-height: 1.4;
+    margin-top: 2px;
 }
 .schedule__day__talk_title .language {
     width: 20px;
     height: auto;
 }
 .schedule__day__talk_speakers {
-    font-size: 10px;
-    margin-bottom: 5px;
+    font-size: 0.8em;
+    margin-bottom: 10px;
 }
 .schedule__day__talk {
     --level-color: gray;
@@ -127,14 +126,11 @@
 .schedule__day__level_indicator {
     display: block;
     width: 100%;
-    position: absolute;
-    left: 0;
-    bottom: 0;
     background: var(--level-color);
     padding-left: 6px;
     color: #ffffff;
-    font-size: 0.7em;
-    min-height: 1.5em;
+    font-size: 0.5em;
+    min-height: 1.8em;
 }
 .talk-level--beginner {
     --level-color: #738023;
@@ -145,11 +141,27 @@
 .talk-level--advanced {
     --level-color: #DA2300;
 }
+.schedule__day__keynote {
+    display: block;
+    width: 100%;
+    background: #00307b;
+    padding-left: 6px;
+    color: #ffffff;
+    font-size: 0.7em;
+    min-height: 1.6em;
+}
+.schedule__day__startend {
+    margin-top: auto;
+    padding-bottom: 0;
+    font-size: 0.5em;
+    min-height: 1.8em;
+    text-align: right;
+}
 .schedule__day__inner {
     width: 100%;
     height: 100%;
     max-width: calc(100vw - 60px);
-    padding: 0 10px 20px 10px;
+    padding: 5px 10px 5px 10px;
     display: flex;
     flex-direction: column;
 }
@@ -170,9 +182,6 @@
 
 #days-navbar {
     background-color: #DE8524;
-    {% comment %} position: sticky; {% endcomment %}
-    top: 0;
-    z-index: 100;
     padding-left: 55px;
 }
 
@@ -188,10 +197,7 @@ div.cms .cms-toolbar {
     position: absolute!important;
 }
 
-.schedule__talks_header, .schedule__time {
-    position: sticky;
-    top: 0;
-    z-index: 20;
+.schedule__talks_header {
     background: white;
 }
 
@@ -231,18 +237,21 @@ div.cms .cms-toolbar {
 
 <div class="schedule">
     <div class="schedule__day">
-        <div>
-            <div class="schedule__grid schedule__grid--header schedule__day--sidebar" style="--cols: 1; --rows: 1;">
-                <div style="background: white;"></div>
+        <div class="schedule__day--sidebar">
+            <div class="schedule__grid schedule__grid--header schedule__day--time" style="--cols: 1; --rows: 1;">
+                <div id="timezone" style="background: white;">UTC</div>
             </div>
 
-            <div class="schedule__grid schedule__day--sidebar" style="--cols: 1; --rows: {{ schedule.grid.rows }};">
+            <div class="schedule__grid schedule__day--time" style="--cols: 1; --rows: {{ schedule.grid.rows }};">
                 {% for time in schedule.grid.times %}
                     <div class="schedule__time" style="
                         grid-row: {{ time.start_row }} / {{ time.end_row }};
                         grid-column: 1 / 1;
                     ">
-                        {{ time.time|date:"H:i" }}
+                        <a class="schedule-time-display"
+			   data-fulltime="{{ time.time|utc|date:'Y-m-d H:i' }}"
+			   name="{{ time.time|utc|date:'H:i' }}-UTC"
+			   href="#{{ time.time|utc|date:'H:i' }}-UTC">{{ time.time|utc|date:'H:i' }}</a>
                     </div>
                 {% endfor %}
             </div>
@@ -265,11 +274,15 @@ div.cms .cms-toolbar {
                         "
                     >
                         <div class="schedule__day__inner">
+                            {% if talk.speakers %}
                             <div class="schedule__day__talk_speakers">
                                 {% for s in talk.speakers %}
-                                    <a href="{% url "profiles:profile" profile_slug=s.slug %}">{{ s.name }}</a>{% if not forloop.last %}, {% endif %}
+                                    <a href="{% url "profiles:profile" profile_slug=s.slug %}">{{ s.name }}</a>
+				   {% if s.company %} ({{ s.company }}) {% endif %}
+                                   {% if not forloop.last %}, {% endif %}
                                 {% endfor %}
                             </div>
+                            {% endif %}
 
                             <div class="schedule__day__talk_title">
                                 {% if talk.slug %}
@@ -300,12 +313,26 @@ div.cms .cms-toolbar {
                             {% endif %}
                             {% endcomment %}
 
-                            {% if talk.level %}
+                            <div class="schedule__day__startend">
+			        <span class="schedule-time-display"
+                                      data-fulltime="{{ talk.start|utc|date:'Y-m-d H:i' }}">
+                                  {{ talk.start|utc|date:'H:i' }}
+                                </span> -
+	                        <span class="schedule-time-display"
+                                      data-fulltime="{{ talk.end|utc|date:'Y-m-d H:i' }}">
+                                  {{ talk.end|utc|date:'H:i' }}
+                                </span>
+                            </div>
+
+                            {% if talk.admin_type == 'k' %}
+                            <div class="schedule__day__keynote">
+                                Keynote
+                            </div>
+                            {% elif talk.level %}
                             <div class="schedule__day__level_indicator">
                                 {{ talk.level }}
                             </div>
                             {% endif %}
-
                         </div>
                     </div>
                 {% endfor %}
@@ -316,4 +343,40 @@ div.cms .cms-toolbar {
 
 {% include "conference/footer/footer.html" %}
 
+
 {% endblock body %}
+
+{% block morejs %}
+
+<script type="text/javascript">
+/* Change all schedule times from UTC to browser local time */
+function format_local_times() {
+    var tz_offset_ms = new Date().getTimezoneOffset() * 60000;
+    $('.schedule-time-display').each(function(i, obj) {
+        var value = obj.dataset.fulltime;
+        var utc_time = new Date(value);
+	var local_time = new Date(utc_time - tz_offset_ms);
+	var h = local_time.getHours();
+	var m = local_time.getMinutes();
+	var text = "";
+	if (h < 10)
+	    text += "0" + h;
+        else
+	    text += h;
+	text += ":";
+	if (m < 10)
+	    text += "0" + m;
+        else
+	    text += m;
+        obj.innerHTML = text;
+	obj.title = local_time.toString();
+        });
+};
+
+$(document).ready(function() {
+    format_local_times();
+    $('#timezone').text("Your Time");
+});
+</script>
+
+{% endblock morejs %}


### PR DESCRIPTION
Change CSS to look more compact and easier to read.

Add logic to display all schedule times in browser local time zone.

Add keynote bars for keynotes instead of level bars.

Add company name to speaker listings.

Add start and end times to all sessions.