### PR TITLE
add time to talk link to show in correct place in schedule, (#1305)

### DIFF
--- a/conference/models.py
+++ b/conference/models.py
@@ -743,7 +743,10 @@ class Talk(models.Model):
         if not event:
             return None
 
-        return event.schedule.get_absolute_url() + '?' + urlencode({'selected': self.slug})
+        url = event.schedule.get_absolute_url()
+        slug = urlencode({'selected': self.slug})
+        time = event.start_time.strftime('%H:%M-UTC')
+        return f"{url}?{slug}#{time}"
 
     def get_slides_url(self):
 

--- a/tests/test_talks.py
+++ b/tests/test_talks.py
@@ -7,7 +7,13 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
 
 from conference.models import TALK_STATUS, TALK_LEVEL
-from tests.factories import UserFactory, TalkFactory, ConferenceTagFactory, TalkSpeakerFactory
+from tests.factories import (
+    EventFactory,
+    UserFactory,
+    TalkFactory,
+    ConferenceTagFactory,
+    TalkSpeakerFactory,
+)
 from tests.common_tools import get_default_conference, redirects_to, template_used, make_user
 
 pytestmark = [pytest.mark.django_db]
@@ -265,3 +271,18 @@ def test_view_slides_url_on_talk_detail_page(client):
     response = client.get(url)
 
     assert 'download/view slides' in response.content.decode().lower()
+
+
+def test_show_talk_link_in_schedule(client):
+    """
+    The talk url points to the schedule, with correct talk slug, and time in utc
+    """
+    get_default_conference()
+    talk = TalkFactory(status=TALK_STATUS.accepted)
+    event = EventFactory(talk=talk)
+    url = talk.get_absolute_url()
+
+    response = client.get(url)
+
+    start_time = event.start_time.strftime('%H:%M-UTC')
+    assert f"{talk.slug}#{start_time}" in response.content.decode()


### PR DESCRIPTION
resolves https://github.com/EuroPython/epcon/issues/1305

It is not necessary to translate the time into local time because: 
- Times are saved in the db as UTC, so this can be passed along to the url
- UTC time is used to generate `name` markers in `schedule__day--sidebar`, so these remain constant as UTC despite what is displayed as local time to the user.

Thanks to @hypha for the solution in the issue ticket!