### PR TITLE
Remove redundant call to publish_page()

### DIFF
--- a/conference/management/commands/create_initial_data_for_dev.py
+++ b/conference/management/commands/create_initial_data_for_dev.py
@@ -127,6 +127,7 @@ class Command(BaseCommand):
                         "generic_content_page_with_sidebar.html"
                     ),
                     published=True,
+                    created_by=admin.user,
                     publication_date=timezone.now(),
                     in_navigation=True,
                     **kwargs,
@@ -137,7 +138,6 @@ class Command(BaseCommand):
                     language="en",
                     body=f"This is the page content for {title}",
                 )
-                publish_page(page, user=admin.user, language="en")
                 print("Created page: ", page.reverse_id, title, page.template)
                 return page
 

--- a/tests/test_provisioning_script.py
+++ b/tests/test_provisioning_script.py
@@ -4,8 +4,6 @@ from django.core.management import call_command
 from pytest import mark
 
 
-# XXX This will have to be investigated further, but not now...
-@mark.skip(reason='Getting a weird error from the script')
 @mark.django_db
 def test_basic_create_initial_data_for_dev_run():
 


### PR DESCRIPTION
As the page is already published, this was causing Django-CMS to fail with a `NodeAlreadySaved` exception from treebeard. The only thing it looked to be doing that `cms.api.create_page()` was not was assigning a user to the page, and this can already be done with `create_page()` using the `created_by` argument.

Fixes #1349.