### PR TITLE
Have the TOC script cleanup headers even more

### DIFF
--- a/assets/js/generate_toc_for_cms.js
+++ b/assets/js/generate_toc_for_cms.js
@@ -16,9 +16,9 @@ function addTOC() {
       var header = $(this);
       var title = header.text();
       var header_id = title
-        .replace(/[ :&\/\$]/g, "-")
+        .replace(/[ \n\t:&\/\$\xa0()]/g, "-")
         .replace(/--+/g, "-")
-        .replace(/[\?!,.\'\"]/g, "");
+        .replace(/[\?!,.\'\"]|^-|-$/g, "");
       header.attr("id", header_id);
       toc +=
         '<li class="toc-li table-of-contents-' +


### PR DESCRIPTION
They will now also ignore leading and trailing hyphens as well
as non-breaking spaces.