### PR TITLE
WIP: PoC to integrate matrix auth with epcon using matrix-synapse-rest-password

### DIFF
--- a/pycon/urls.py
+++ b/pycon/urls.py
@@ -6,6 +6,7 @@ from django.views.generic import RedirectView
 from filebrowser.sites import site as fsite
 
 from conference.accounts import urlpatterns as accounts_urls
+from conference.accounts import matrix_auth
 from conference.cart import urlpatterns as cart_urls
 from conference.cfp import urlpatterns as cfp_urls
 from conference.debug_panel import urlpatterns as debugpanel_urls
@@ -51,6 +52,12 @@ urlpatterns = [
 
     # production debug panel
     re_path(r'^nothing-to-see-here/', include((debugpanel_urls, 'conference'), namespace='debug_panel')),
+    # matrix
+    re_path(
+        r"^_matrix-internal/identity/v1/check_credentials/$",
+        matrix_auth,
+        name="matrix_auth",
+    )
 ]
 
 if settings.DEBUG:

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ addopts =
     # traceback print mode native
     --tb=native
     # coverage report
-    --cov-config .coveragerc --cov=./ --cov-report=term
+#    --cov-config .coveragerc --cov=./ --cov-report=term
 
 filterwarnings =
     ignore:Coverage disabled via --no-cov switch!

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,6 +1,11 @@
+import json
+
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import mail
+from django.test import Client
 from django.test.client import RequestFactory
+from django.urls import reverse
+
 from pytest import mark
 
 from conference.accounts import send_verification_email
@@ -28,3 +33,80 @@ def test_send_verification_email():
     assert len(message.recipients()) == 1
     assert message.recipients()[0] == user.email
     assert current_site.domain in message.body
+
+@mark.django_db
+def test_matrix_endpoint_ok():
+    user = factories.UserFactory(password="mate_cafe_harina")
+
+    PAYLOAD = {
+        "user": {
+        "id": f"@matrix.{user.username}:europython.eu",
+        "password": "mate_cafe_harina"
+      }
+    }
+    EXPECTED_SUCCESS = {
+        "auth": {
+            "success": True,
+            "mxid": f"@matrix.{user.username}:europython.eu",
+        }
+    }
+    client= Client()
+
+    r = client.post(reverse("accounts:matrix_auth"), PAYLOAD, content_type="application/json")
+    assert r.status_code == 200
+    response_data = r.json()
+    assert response_data["auth"]["success"]
+    assert response_data["auth"]["mxid"] == EXPECTED_SUCCESS["auth"]["mxid"]
+
+
+@mark.django_db
+def test_matrix_endpoint_denied():
+    user = factories.UserFactory(password="mate_cafe_harina")
+
+    PAYLOAD = {
+        "user": {
+        "id": f"@matrix.{user.username}:europython.eu",
+        "password": "wrong_password"
+      }
+    }
+    EXPECTED_ERROR = {
+        "auth": {
+            "success": False,
+        }
+    }
+    client= Client()
+
+    r = client.post(reverse("accounts:matrix_auth"), PAYLOAD, content_type="application/json")
+    assert r.status_code == 200
+    r.json() == EXPECTED_ERROR
+
+@mark.django_db
+def test_matrix_endpoint_profile():
+    user = factories.UserFactory(password="mate_cafe_harina")
+
+    PAYLOAD = {
+        "user": {
+        "id": f"@matrix.{user.username}:europython.eu",
+        "password": "mate_cafe_harina"
+      }
+    }
+    EXPECTED_SUCCESS = {
+        "auth": {
+            "success": True,
+            "mxid": f"@matrix.{user.username}:europython.eu",
+            "profile": {
+                "display_name": f"{user.first_name} {user.last_name}",
+                "three_pids": [
+                    {
+                        "medium": "email",
+                        "address": user.email,
+                    },
+                ]
+            }
+        }
+    }
+    client= Client()
+
+    r = client.post(reverse("accounts:matrix_auth"), PAYLOAD, content_type="application/json")
+    assert r.status_code == 200
+    assert r.json() == EXPECTED_SUCCESS


### PR DESCRIPTION
This is a PoC to authenticate Matrix users in our epcon website using: https://github.com/ma1uta/matrix-synapse-rest-password-provider

It requires to reconfigure matrix: https://github.com/EuroPython/ep-matrix/blob/ep2021/docs/configuring-playbook-rest-auth.md

```
diff --git a/inventory/host_vars/matrix.europython.eu/vars.yml b/inventory/host_vars/matrix.europython.eu/vars.yml
index 7f678820..ce6beece 100644
--- a/inventory/host_vars/matrix.europython.eu/vars.yml
+++ b/inventory/host_vars/matrix.europython.eu/vars.yml
@@ -45,3 +45,12 @@ matrix_synapse_container_additional_volumes:
 matrix_synapse_configuration_extension_yaml: |
   third_party_event_rules:
     module: "epmatrix.SuperRulesSet"
+
+
+# rest_auth_endpoint in epcon.
+matrix_synapse_ext_password_provider_rest_auth_enabled: true
+matrix_synapse_ext_password_provider_rest_auth_endpoint: "http://62.163.214.55:8888"
+matrix_synapse_ext_password_provider_rest_auth_registration_enforce_lowercase: false
+matrix_synapse_ext_password_provider_rest_auth_registration_profile_name_autofill: true
+matrix_synapse_ext_password_provider_rest_auth_login_profile_name_autofill: false
+matrix_synapse_password_config_localdb_enabled: false
```

Example log in my local from the Matrix server:
```
epcon_1  | b'{"user": {"id": "@testuser:europython.eu", "password": "tujavie"}}'
epcon_1  | 
epcon_1  | 
epcon_1  | 
epcon_1  | 
epcon_1  | 
epcon_1  | [08/May/2021 22:40:53] "POST /_matrix-internal/identity/v1/check_credentials/ HTTP/1.1" 200 148
```

The user was created:
![image](https://user-images.githubusercontent.com/1496486/117553050-782c3480-b04f-11eb-9d51-271dcf272d71.png)

![image](https://user-images.githubusercontent.com/1496486/117553055-7f534280-b04f-11eb-8944-e48bd20c1ef7.png)


Problems to solve: 
Matrix is sending the "username" and we don't have usernames. we use e-mail. I think we have to learn how to config it. It has to be something related to 3PIDs

The URL used by the plugin is not using a slash at the end. Our Django is configured to expect one: https://github.com/ma1uta/matrix-synapse-rest-password-provider/blob/master/rest_auth_provider.py#L50

Of course it's just a test, we have to check that the user has a ticket. and we can maybe do some extra work after (like adding to a channel if the user is a speaker, etc) 


I didn't investigate it but we can maybe just create our version of the rest_auth_provider
