### PR TITLE
Use pip-compile with --generate-hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ drop-db:
 redo-db: drop-db init-db
 
 update-requirements: build
-	docker-compose run --rm epcon "pip install pip-tools -U && pip-compile -U requirements.in -o requirements.txt && chmod a+r requirements.txt && pip-compile -U requirements-dev.in -o requirements-dev.txt && chmod a+r requirements-dev.txt"
+	docker-compose run --rm epcon "pip install pip-tools -U && pip-compile -U --generate-hashes requirements.in -o requirements.txt && chmod a+r requirements.txt && pip-compile -U requirements-dev.in -o requirements-dev.txt && chmod a+r requirements-dev.txt"
 
 migrations: build
 	docker-compose run --rm epcon "./manage.py makemigrations"


### PR DESCRIPTION
Sadly it's not possible to compile requirements-dev.in with --generate-hashes, think because of
using editables? See: https://github.com/pypa/pip/issues/4995

Maybe it's better to switch from pip-tools to poetry or pipenv ;)

related issues: https://github.com/EuroPython/epcon/issues/1401