### PR TITLE
Prepare for Matrix stream widgets

### DIFF
--- a/conference/templatetags/conference.py
+++ b/conference/templatetags/conference.py
@@ -145,10 +145,11 @@ def tickets(user):
     """
     return get_tickets_for_current_conference(user)
 
-@register.simple_tag
-def visible_streams(user):
+@register.simple_tag(takes_context=True)
+def visible_streams(context, user):
     """ Return the list of currently active streams as dictionaries:
         - title
         - url
     """
-    return get_streams_for_current_conference(user)
+    request = context['request']
+    return get_streams_for_current_conference(user, request=request)

--- a/conference/user_panel.py
+++ b/conference/user_panel.py
@@ -635,7 +635,10 @@ def get_streams_for_current_conference(user, request=None):
         fare_codes = set()
 
     # Allow filtering by title
-    title_filter = request.GET.get('title')
+    if request is not None:
+        title_filter = request.GET.get('title')
+    else:
+        title_filter = None
 
     #print ('User has these fares: %r' % fare_codes)
     conference = Conference.objects.current()

--- a/conference/user_panel.py
+++ b/conference/user_panel.py
@@ -584,7 +584,13 @@ def get_tickets_for_current_conference(user):
 
 def matrix_token_access(request):
 
+    """ Check whether a Matrix embedding token was passed in
+    
+    """
     #print ('Configured token: %r' % settings.MATRIX_STREAM_EMBEDDING_TOKEN)
+
+    if request is None:
+        return False
 
     # Token check
     if settings.MATRIX_STREAM_EMBEDDING_TOKEN is None:

--- a/conference/user_panel.py
+++ b/conference/user_panel.py
@@ -582,14 +582,55 @@ def get_tickets_for_current_conference(user):
     )
 
 
-def get_streams_for_current_conference(user):
+def matrix_token_access(request):
+
+    #print ('Configured token: %r' % settings.MATRIX_STREAM_EMBEDDING_TOKEN)
+
+    # Token check
+    if settings.MATRIX_STREAM_EMBEDDING_TOKEN is None:
+        return False
+    token = request.GET.get('token')
+    #print ('Found token: %r' % token)
+    if token is None:
+        return False
+    if token != settings.MATRIX_STREAM_EMBEDDING_TOKEN:
+        return False
+
+    # Referer check
+    if settings.MATRIX_STREAM_EMBEDDING_REFERER is not None:
+        referrer = request.META.get('HTTP_REFERER')
+        #print ('Referrer: %r' % referrer)
+        if referrer is None:
+            return False
+        elif referrer.startswith(settings.MATRIX_STREAM_EMBEDDING_REFERER):
+            # check passes
+            pass
+        else:
+            return False
+
+    return True
+
+def get_streams_for_current_conference(user, request=None):
 
     """ Return the list of currently active streams as dictionaries:
         - title
         - url
     """
-    fare_codes = set(
-        get_tickets_for_current_conference(user).values_list("fare__code", flat=True))
+    if user.is_authenticated:
+        # Authenticated user: use tickets
+        fare_codes = set(
+            get_tickets_for_current_conference(user).values_list("fare__code", flat=True))
+    elif matrix_token_access(request):
+        # Use token fares
+        #print ('Allow Matrix embedding')
+        fare_codes = settings.MATRIX_STREAM_EMBEDDING_FARES
+    else:
+        # No fares available
+        fare_codes = set()
+
+    # Allow filtering by title
+    title_filter = request.GET.get('title')
+
     #print ('User has these fares: %r' % fare_codes)
     conference = Conference.objects.current()
     now = timezone.now()
@@ -612,6 +653,9 @@ def get_streams_for_current_conference(user):
             stream_fare_codes = set(stream.get('fare_codes', ()))
             #print ('Stream requires these fare codes: %r' % stream_fare_codes)
             if stream_fare_codes & fare_codes:
+                if title_filter:
+                    if stream['title'] != title_filter:
+                        continue
                 streams.append({
                     'title': stream['title'],
                     'url': stream['url'],

--- a/pycon/settings.py
+++ b/pycon/settings.py
@@ -480,7 +480,6 @@ SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 if HTTPS:
     # Use secure cookie settings when using HTTPS
     SESSION_COOKIE_SECURE = True
-    SESSION_COOKIE_SAMESITE = 'None'
 
 CONFERENCE_CONFERENCE = 'ep2021'
 CONFERENCE_NAME = "EuroPython 2021"

--- a/pycon/settings.py
+++ b/pycon/settings.py
@@ -35,6 +35,11 @@ if not DEBUG:
     HTTPS = True
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+else:
+    # In dev mode, allow configuring the HTTPS support via the env
+    HTTPS = (os.environ.get('HTTPS', 'off') == 'on')
+    if HTTPS:
+        SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 ADMINS = (("web-wg", "web-wg@europython.eu"),)
 MANAGERS = ADMINS
@@ -373,6 +378,22 @@ PAGE_REAL_TIME_SEARCH = False
 
 PAGE_USE_STRICT_URL = True
 
+### Django CMS
+
+# Disable CMS content caching
+#
+# See https://docs.divio.com/en/latest/background/caching/#caching-with-aldryn-django-legacy
+# for details.
+#
+# Not doing so, puts the system at risk, since it could potentially deliver
+# content which was rendered for a user with different permissions.
+#
+CMS_CACHE_DURATIONS = {
+    'menus': 60,
+    'content': 0,
+    'permissions': 60,
+}
+
 CMS_LANGUAGES = {
     1: [
         {
@@ -394,6 +415,10 @@ CMS_TEMPLATES = (
      'Generic Content Page (with sidebar)'),
     ('conference/homepage/home_template.html',
      'Homepage'),
+    ('conference/content/wide_content_page.html',
+     'Wide Content Page'),
+    ('conference/content/content_only_page.html',
+     'Content Only Page'),
 )
 PAGE_TEMPLATES = (
     ('conference/content/generic_content_page_with_sidebar.html',
@@ -452,6 +477,10 @@ MESSAGE_STORAGE = 'django.contrib.messages.storage.cookie.CookieStorage'
 #
 SESSION_COOKIE_NAME = 'sid'
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+if HTTPS:
+    # Use secure cookie settings when using HTTPS
+    SESSION_COOKIE_SECURE = True
+    SESSION_COOKIE_SAMESITE = 'None'
 
 CONFERENCE_CONFERENCE = 'ep2021'
 CONFERENCE_NAME = "EuroPython 2021"
@@ -739,3 +768,28 @@ MATRIX_AUTH_API_ALLOWED_IPS = config(
     default='',
     cast=lambda v: [s.strip() for s in v.split(',') if s.strip()]
 )
+
+### Matrix stream embedding
+
+# Token to accept
+#
+# Normally, users have to be logged in to allow seeing streams based on
+# their tickets.  With the token, this can be overridden to e.g.  permit
+# Matrix widgets to show streams without having the user log in first.
+#
+MATRIX_STREAM_EMBEDDING_TOKEN = config(
+    'MATRIX_STREAM_EMBEDDING_TOKEN',
+    default=None
+)
+
+# Referer to accept
+#
+# This is optional and only checked if given.
+#
+MATRIX_STREAM_EMBEDDING_REFERER = config(
+    'MATRIX_STREAM_EMBEDDING_REFERER',
+    default=None
+)
+
+# Fare code set to assume when using stream embedding
+MATRIX_STREAM_EMBEDDING_FARES = set(['TRCC'])

--- a/templates/conference/base.html
+++ b/templates/conference/base.html
@@ -49,7 +49,10 @@
     <script src="{% static 'js/bootstrap.min.js' %}"></script>
     {% block morejs %}{% endblock %}
 
+    {% block cookieconsent %}
     {% include "conference/_cookie_consent.html" %}
+    {% endblock %}
+
     {% render_block "js" %} {# FOR DJANGO CMS #}
   </body>
 </html>

--- a/templates/conference/content/content_only_page.html
+++ b/templates/conference/content/content_only_page.html
@@ -1,0 +1,35 @@
+{% extends "conference/base.html" %}
+
+{% load menu_tags cms_tags static %}
+
+{% block body %}
+{% include "conference/content/_messages.html" %}
+<div id="content_page">
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-lg-12 col-12">
+                <div id="content" class="epcms_content">
+                    {% placeholder "text" %}
+                </div>
+            </div>
+        </div><!-- .row -->
+    </div>
+</div>
+{% endblock %}
+
+{% block morejs %}
+<!-- No TOC generation script loaded -->
+{% endblock morejs %}
+
+{% block cookieconsent %}
+<!-- No cookie consent banner shown -->
+{% endblock %}
+
+{% block morecss %}
+<style>
+    img.filer_image {
+        max-width: 100%;
+        height: auto;
+    }
+</style>
+{% endblock morecss %}

--- a/templates/conference/content/content_only_page.html
+++ b/templates/conference/content/content_only_page.html
@@ -7,11 +7,13 @@
 <div id="content_page">
     <div class="container-fluid">
         <div class="row">
-            <div class="col-lg-12 col-12">
+            <div class="col-lg-1 col-1"></div>
+            <div class="col-lg-10 col-10">
                 <div id="content" class="epcms_content">
                     {% placeholder "text" %}
                 </div>
             </div>
+            <div class="col-lg-1 col-1"></div>
         </div><!-- .row -->
     </div>
 </div>

--- a/templates/conference/content/wide_content_page.html
+++ b/templates/conference/content/wide_content_page.html
@@ -1,0 +1,35 @@
+{% extends "conference/base.html" %}
+
+{% load menu_tags cms_tags static %}
+
+{% block content %}
+<div id="content_page">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12">
+                <h1>{% page_attribute "title" %}</h1>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-12 col-12">
+                <div id="content" class="epcms_content">
+                    {% placeholder "text" %}
+                </div>
+            </div>
+        </div><!-- .row -->
+    </div>
+</div>
+{% endblock %}
+
+{% block morejs %}
+<script src="{% static "/js/generate_toc_for_cms.js" %}"></script>
+{% endblock morejs %}
+
+{% block morecss %}
+<style>
+    img.filer_image {
+        max-width: 100%;
+        height: auto;
+    }
+</style>
+{% endblock morecss %}


### PR DESCRIPTION
Since the Matrix iframes do not send the session cookie from an
already logged in browser tab, we have to resort to using a token
for getting access to the page.

Disable CMS caching of pages, since otherwise the token access check
would be cached for all users.